### PR TITLE
feat(wallet): add Stellar wallet identity model and service boundary

### DIFF
--- a/prisma/schema/user.prisma
+++ b/prisma/schema/user.prisma
@@ -11,4 +11,5 @@ model User {
 
 	avatar					String?
 	
+	stellarWallet		StellarWallet?
 }

--- a/prisma/schema/wallet.prisma
+++ b/prisma/schema/wallet.prisma
@@ -1,0 +1,10 @@
+model StellarWallet {
+  id        String   @id @default(cuid())
+  address   String   @unique
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String   @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([address])
+}

--- a/src/modules/wallet/README.md
+++ b/src/modules/wallet/README.md
@@ -1,0 +1,37 @@
+# Wallet Identity Module
+
+This module defines the mapping between application users and their Stellar public wallet addresses.
+
+## StellarWallet Model
+
+The `StellarWallet` model is a 1:1 relationship with the `User` model, serving as a clean identity boundary for Stellar-related features.
+
+- **`address`**: The Stellar public key (G-address).
+- **`userId`**: Foreign key to the `User` model.
+- **`createdAt/updatedAt`**: Standard timestamps.
+
+## Validation Assumptions
+
+Stellar public addresses (G-addresses) must satisfy the following criteria:
+
+1. **Length**: Exactly 56 characters long.
+2. **Identifier**: Must start with the character 'G' (denoting a public key).
+3. **Encoding**: Must use Stellar's Base32 encoding (A-Z and digits 2-7).
+
+### Schema Validation (Zod)
+
+```typescript
+export const StellarAddressSchema = z
+   .string()
+   .length(56, 'Stellar address must be exactly 56 characters long')
+   .regex(/^G[A-Z2-7]{55}$/, 'Invalid Stellar public key format');
+```
+
+## Service Boundary
+
+The service boundary is defined in `wallet.utils.ts` and `wallet.types.ts`, providing methods for:
+
+- **`upsertStellarWallet`**: Mapping/updating a user's Stellar address.
+- **`getStellarWalletByUserId`**: Retrieving the wallet for a specific user.
+- **`getUserByStellarAddress`**: Reverse lookup of a user by their wallet address.
+- **`isStellarAddressRegistered`**: Checking if an address is already in use.

--- a/src/modules/wallet/wallet.schemas.ts
+++ b/src/modules/wallet/wallet.schemas.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Validation assumptions for Stellar wallet addresses:
+ * 1. Must be exactly 56 characters long.
+ * 2. Must start with 'G' (Stellar public key identifier).
+ * 3. Must follow Base32 encoding (A-Z, 2-7).
+ */
+export const StellarAddressSchema = z
+  .string()
+  .length(56, 'Stellar address must be exactly 56 characters long')
+  .regex(/^G[A-Z2-7]{55}$/, 'Invalid Stellar public key format (must start with G and use Base32 characters)');
+
+export const MapUserToWalletSchema = z.object({
+  userId: z.string().cuid('Invalid user ID format (CUID expected)'),
+  address: StellarAddressSchema,
+});
+
+export type MapUserToWalletType = z.infer<typeof MapUserToWalletSchema>;

--- a/src/modules/wallet/wallet.utils.ts
+++ b/src/modules/wallet/wallet.utils.ts
@@ -1,0 +1,64 @@
+import { prisma } from '../../utils/prisma.utils';
+import { MapUserToWalletType } from './wallet.schemas';
+
+/**
+ * Service boundary for Stellar wallet identity mapping.
+ * Handles the association between application users and their Stellar public addresses.
+ */
+
+/**
+ * Associates a Stellar address with a user.
+ * If the user already has a wallet, it updates the address.
+ * Ensures the address is unique across the system.
+ */
+export const upsertStellarWallet = async (input: MapUserToWalletType) => {
+  return await prisma.stellarWallet.upsert({
+    where: {
+      userId: input.userId,
+    },
+    update: {
+      address: input.address,
+    },
+    create: {
+      userId: input.userId,
+      address: input.address,
+    },
+  });
+};
+
+/**
+ * Retrieves the Stellar wallet associated with a user ID.
+ */
+export const getStellarWalletByUserId = async (userId: string) => {
+  return await prisma.stellarWallet.findUnique({
+    where: {
+      userId,
+    },
+  });
+};
+
+/**
+ * Retrieves the user associated with a Stellar address.
+ */
+export const getUserByStellarAddress = async (address: string) => {
+  return await prisma.stellarWallet.findUnique({
+    where: {
+      address,
+    },
+    include: {
+      user: true,
+    },
+  });
+};
+
+/**
+ * Checks if a Stellar address is already registered in the system.
+ */
+export const isStellarAddressRegistered = async (address: string) => {
+  const wallet = await prisma.stellarWallet.findUnique({
+    where: {
+      address,
+    },
+  });
+  return !!wallet;
+};

--- a/src/types/wallet.types.ts
+++ b/src/types/wallet.types.ts
@@ -1,0 +1,23 @@
+import { StellarWallet, User } from '@prisma/client';
+
+/**
+ * Represent a Stellar wallet identity mapping.
+ */
+export type StellarWalletIdentity = StellarWallet;
+
+/**
+ * Represent a Stellar wallet identity with associated user profile.
+ */
+export type StellarWalletWithUser = StellarWallet & {
+  user: User;
+};
+
+/**
+ * Interface for the wallet service boundary.
+ */
+export interface IStellarWalletService {
+  upsertStellarWallet(userId: string, address: string): Promise<StellarWallet>;
+  getStellarWalletByUserId(userId: string): Promise<StellarWallet | null>;
+  getUserByStellarAddress(address: string): Promise<StellarWalletWithUser | null>;
+  isStellarAddressRegistered(address: string): Promise<boolean>;
+}


### PR DESCRIPTION
Closes #4

---

This PR introduces the StellarWallet identity model and a clean service boundary for mapping application users to their Stellar public addresses. This setup provides the foundation for future wallet-aware features and access control without coupling ownership logic directly into the core user module.

Changes

- Schema : Added wallet.prisma and updated user.prisma to support the 1:1 identity relationship.
- Validation : Implemented StellarAddressSchema in wallet.schemas.ts ensuring all addresses follow Stellar's G-address format (56 chars, Base32).
- Service Boundary : Created wallet.utils.ts with upsertStellarWallet , getStellarWalletByUserId , and getUserByStellarAddress utilities.
- Types : Defined wallet.types.ts for consistent internal type safety.
- Documentation : Added a module README.md detailing validation assumptions and architectural intent.
Validation Assumptions

- Addresses must be exactly 56 characters.
- Addresses must start with 'G'.
- Addresses must use Stellar's Base32 character set (A-Z, 2-7).

close issue #4 