### PR TITLE
feat: add creator list sort mapper

### DIFF
--- a/src/modules/creators/creators.schemas.ts
+++ b/src/modules/creators/creators.schemas.ts
@@ -1,4 +1,8 @@
 import { z } from 'zod';
+import {
+   CREATOR_LIST_SORT_OPTIONS,
+   CREATOR_LIST_SORT_ORDERS,
+} from './creators.sort';
 
 /**
  * Validation schema for creator list query parameters.
@@ -29,11 +33,8 @@ export const CreatorListQuerySchema = z.object({
       }),
 
    // Sorting
-   sort: z
-      .enum(['createdAt', 'updatedAt', 'displayName', 'handle'])
-      .optional()
-      .default('createdAt'),
-   order: z.enum(['asc', 'desc']).optional().default('desc'),
+   sort: z.enum(CREATOR_LIST_SORT_OPTIONS).optional().default('createdAt'),
+   order: z.enum(CREATOR_LIST_SORT_ORDERS).optional().default('desc'),
 
    // Filters
    verified: z

--- a/src/modules/creators/creators.sort.ts
+++ b/src/modules/creators/creators.sort.ts
@@ -1,0 +1,46 @@
+import { Prisma } from '@prisma/client';
+
+/**
+ * Public sort options accepted by creator list endpoints.
+ * These remain stable even if the internal query implementation changes.
+ */
+export const CREATOR_LIST_SORT_OPTIONS = [
+   'createdAt',
+   'updatedAt',
+   'displayName',
+   'handle',
+] as const;
+
+export const CREATOR_LIST_SORT_ORDERS = ['asc', 'desc'] as const;
+
+export type CreatorListSortOption = (typeof CREATOR_LIST_SORT_OPTIONS)[number];
+export type CreatorListSortOrder = (typeof CREATOR_LIST_SORT_ORDERS)[number];
+
+const CREATOR_LIST_SORT_FIELD_MAP: Record<
+   CreatorListSortOption,
+   keyof Prisma.CreatorProfileOrderByWithRelationInput
+> = {
+   createdAt: 'createdAt',
+   updatedAt: 'updatedAt',
+   displayName: 'displayName',
+   handle: 'handle',
+};
+
+/**
+ * Map a public sort option into an internal Prisma orderBy object.
+ * Throws for unsupported values so invalid sort input is never passed through silently.
+ */
+export function mapCreatorListSort(
+   sort: string,
+   order: CreatorListSortOrder
+): Prisma.CreatorProfileOrderByWithRelationInput {
+   const field = CREATOR_LIST_SORT_FIELD_MAP[sort as CreatorListSortOption];
+
+   if (!field) {
+      throw new Error(`Unsupported creator sort option: ${sort}`);
+   }
+
+   return {
+      [field]: order,
+   } as Prisma.CreatorProfileOrderByWithRelationInput;
+}

--- a/src/modules/creators/creators.utils.ts
+++ b/src/modules/creators/creators.utils.ts
@@ -1,6 +1,7 @@
 import { prisma } from '../../utils/prisma.utils';
 import { CreatorProfile } from '../../types/profile.types';
 import { CreatorListQueryType } from './creators.schemas';
+import { mapCreatorListSort } from './creators.sort';
 
 type CreatorListWhere = {
    isVerified?: boolean;
@@ -35,8 +36,7 @@ export async function fetchCreatorList(
       ];
    }
 
-   // Build order by clause
-   const orderBy = { [sort]: order };
+   const orderBy = mapCreatorListSort(sort, order);
 
    // Fetch creators and total count in parallel
    const [creators, total] = await Promise.all([


### PR DESCRIPTION
## Summary
- add a dedicated creator list sort mapper for translating allowed public sort values into internal query behavior
- centralize allowed creator list sort options and sort orders in one reusable module
- update creator list schema validation to use the shared sort constants
- stop passing the public `sort` value directly into Prisma `orderBy`

## Testing
- corepack pnpm lint
- corepack pnpm exec prettier --write src/modules/creators/creators.sort.ts src/modules/creators/creators.schemas.ts src/modules/creators/creators.utils.ts

## Notes
- `corepack pnpm build` is currently blocked by Prisma client generation/type availability in the repo environment, including existing errors in unrelated files outside this change
- `corepack pnpm generate` hung locally instead of completing, so full build validation could not be completed here

Closes #33
