### PR TITLE
feat: Add creator param not-found shortcut helper

### DIFF
--- a/src/modules/creator/creator.utils.ts
+++ b/src/modules/creator/creator.utils.ts
@@ -1,5 +1,8 @@
 // src/modules/creator/creator.utils.ts
 import { Prisma } from '@prisma/client';
+import { Response } from 'express';
+import { prisma } from '../../utils/prisma.utils';
+import { sendNotFound } from '../../utils/api-response.utils';
 
 export type CreatorSortField = 'createdAt' | 'handle' | 'displayName';
 export type SortOrder = 'asc' | 'desc';
@@ -40,4 +43,66 @@ export function toPrismaOrderBy(
    return {
       [options.field]: options.order,
    };
+}
+
+/**
+ * Shortcut helper for returning a not-found response when a creator param is missing.
+ *
+ * This reduces repeated route-level boilerplate by centralizing the creator
+ * not-found check. If the creator exists, it returns the creator object.
+ * If not found, it sends a 404 response and returns null.
+ *
+ * @param res - Express response object
+ * @param creatorId - Creator ID to look up
+ * @returns Creator profile if found, null otherwise (with 404 response already sent)
+ *
+ * @example
+ * const creator = await getCreatorOrNotFound(res, creatorId);
+ * if (!creator) return; // 404 already sent
+ * // Continue with creator...
+ */
+export async function getCreatorOrNotFound(
+   res: Response,
+   creatorId: string
+): Promise<Prisma.CreatorProfileGetPayload<{}> | null> {
+   const creator = await prisma.creatorProfile.findUnique({
+      where: { id: creatorId },
+   });
+
+   if (!creator) {
+      sendNotFound(res, 'Creator');
+      return null;
+   }
+
+   return creator;
+}
+
+/**
+ * Shortcut helper for returning a not-found response when a creator handle param is missing.
+ *
+ * Similar to getCreatorOrNotFound, but looks up creators by handle instead of ID.
+ *
+ * @param res - Express response object
+ * @param handle - Creator handle to look up
+ * @returns Creator profile if found, null otherwise (with 404 response already sent)
+ *
+ * @example
+ * const creator = await getCreatorByHandleOrNotFound(res, handle);
+ * if (!creator) return; // 404 already sent
+ * // Continue with creator...
+ */
+export async function getCreatorByHandleOrNotFound(
+   res: Response,
+   handle: string
+): Promise<Prisma.CreatorProfileGetPayload<{}> | null> {
+   const creator = await prisma.creatorProfile.findUnique({
+      where: { handle },
+   });
+
+   if (!creator) {
+      sendNotFound(res, 'Creator');
+      return null;
+   }
+
+   return creator;
 }


### PR DESCRIPTION
Closes #46 
## Summary

This PR adds reusable helper functions for quickly returning not-found responses when creator parameters are missing. This addresses issue #46 by centralizing creator not-found logic and reducing repeated route-level boilerplate.

## Changes

### Added to `src/modules/creator/creator.utils.ts`:

1. **`getCreatorOrNotFound(res, creatorId)`** - Looks up creators by ID
2. **`getCreatorByHandleOrNotFound(res, handle)`** - Looks up creators by handle

Both helpers:
- Query the database for the creator
- Return the creator if found
- Send a 404 response and return null if not found
- Are fully documented with JSDoc comments

## Benefits

- **Reduces boilerplate**: Route handlers can now use a single line to check if a creator exists instead of duplicating lookup and error handling logic
- **Centralized logic**: All creator not-found behavior is kept in one place for consistency
- **Reusable**: Both helpers can be used across all creator endpoints
- **Predictable**: Consistent behavior across all routes that use these helpers

## Usage Example

```typescript
// Before (repeated in every route):
const creator = await prisma.creatorProfile.findUnique({
  where: { id: creatorId }
});
if (!creator) {
  return sendNotFound(res, 'Creator');
}
// Continue with creator...

// After (single line):
const creator = await getCreatorOrNotFound(res, creatorId);
if (!creator) return; // 404 already sent
// Continue with creator...
```

## Testing

- ✅ Code compiles successfully with `pnpm build`
- ✅ Follows existing codebase patterns and conventions
- ✅ Includes comprehensive JSDoc documentation
- ✅ Uses existing `sendNotFound` helper from `api-response.utils.ts`

## Checklist

- [x] Code follows the project's coding standards
- [x] Documentation added for new functions
- [x] No breaking changes introduced
- [x] Tested that the code compiles successfully
- [x] Changes are backward compatible
