### PR TITLE
feat: add creator route constants and replace repeated route strings

### DIFF
--- a/src/constants/creator.constants.ts
+++ b/src/constants/creator.constants.ts
@@ -1,0 +1,8 @@
+// src/constants/creator.constants.ts
+// Centralized creator route segments used across modules.
+
+/** Base path for creator collection routes. */
+export const BASE = '/creators';
+
+/** Root segment for creator module routes. */
+export const ROOT = '/';

--- a/src/modules/creator/creator.routes.ts
+++ b/src/modules/creator/creator.routes.ts
@@ -1,6 +1,7 @@
 // src/modules/creator/creator.routes.ts
 import { Router } from 'express';
 import { listCreators } from './creator.controller';
+import { ROOT as CREATORS_ROOT } from '../../constants/creator.constants';
 
 const router = Router();
 
@@ -9,6 +10,6 @@ const router = Router();
  * @desc Get a paginated list of creators
  * @access Public
  */
-router.get('/', listCreators);
+router.get(CREATORS_ROOT, listCreators);
 
 export default router;

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -3,12 +3,13 @@ import authRouter from './auth/auth.routes';
 import healthRouter from './health/health.routes';
 import configRouter from './config/config.routes';
 import creatorRouter from './creator/creator.routes';
+import { BASE as CREATORS_BASE } from '../constants/creator.constants';
 
 const router = Router();
 
 router.use('/health', healthRouter);
 router.use('/auth', authRouter);
 router.use('/config', configRouter);
-router.use('/creators', creatorRouter);
+router.use(CREATORS_BASE, creatorRouter);
 
 export default router;


### PR DESCRIPTION
Closes #47 

## Summary

- Added creator route constants in `src/constants/creator.constants.ts`
- Replaced hardcoded `/creators` and `/` in creator routing with constants
- No behavior changes

## Testing

- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] `pnpm exec prisma generate` (not required)

## Checklist

- [x] Linked issue or backlog item (#47)
- [x] No secrets or live credentials added
- [ ] Docs updated if setup or env changed (not required)
- [x] Change is scoped to one problem