### PR TITLE
feat: add shared setPublicHeaders helper for public endpoints

### DIFF
--- a/src/modules/config/config.routes.ts
+++ b/src/modules/config/config.routes.ts
@@ -1,6 +1,7 @@
 // src/modules/config/config.routes.ts
 import { Router } from 'express';
 import { httpGetProtocolConfig } from './config.controllers';
+import { setPublicHeaders } from '../../utils/public-headers.utils';
 
 const configRouter = Router();
 
@@ -9,6 +10,6 @@ const configRouter = Router();
  * Public endpoint returning protocol bootstrap configuration.
  * Safe for unauthenticated use - no sensitive data exposed.
  */
-configRouter.get('/', httpGetProtocolConfig);
+configRouter.get('/', setPublicHeaders, httpGetProtocolConfig);
 
 export default configRouter;

--- a/src/modules/creator/creator.routes.ts
+++ b/src/modules/creator/creator.routes.ts
@@ -1,6 +1,7 @@
 // src/modules/creator/creator.routes.ts
 import { Router } from 'express';
 import { listCreators } from './creator.controller';
+import { setPublicHeaders } from '../../utils/public-headers.utils';
 
 const router = Router();
 
@@ -9,6 +10,6 @@ const router = Router();
  * @desc Get a paginated list of creators
  * @access Public
  */
-router.get('/', listCreators);
+router.get('/', setPublicHeaders, listCreators);
 
 export default router;

--- a/src/modules/creators/creators.routes.ts
+++ b/src/modules/creators/creators.routes.ts
@@ -1,9 +1,6 @@
 import { Router } from 'express';
 import { httpListCreators } from './creators.controllers';
-import {
-   cacheControl,
-   CachePresets,
-} from '../../middlewares/cache-control.middleware';
+import { setPublicHeaders } from '../../utils/public-headers.utils';
 
 const creatorsRouter = Router();
 
@@ -13,10 +10,6 @@ const creatorsRouter = Router();
  * List all creators with pagination and filtering.
  * Public endpoint with 5-minute cache.
  */
-creatorsRouter.get(
-   '/',
-   cacheControl(CachePresets.publicShort),
-   httpListCreators
-);
+creatorsRouter.get('/', setPublicHeaders, httpListCreators);
 
 export default creatorsRouter;

--- a/src/utils/public-headers.utils.ts
+++ b/src/utils/public-headers.utils.ts
@@ -1,0 +1,11 @@
+import { Request, Response, NextFunction } from 'express';
+import { cacheControl, CachePresets } from '../middlewares/cache-control.middleware';
+
+/**
+ * Sets common headers for public, read-only endpoints.
+ * Applies a short public cache and marks the response as non-credentialed.
+ */
+export function setPublicHeaders(req: Request, res: Response, next: NextFunction): void {
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  cacheControl(CachePresets.publicShort)(req, res, next);
+}


### PR DESCRIPTION
- add src/utils/public-headers.utils.ts with setPublicHeaders middleware
- applies Cache-Control (public, max-age=300) via existing CachePresets.publicShort
- sets X-Content-Type-Options: nosniff on all public GET responses
- replace inline cacheControl usage in creator.routes.ts and creators.routes.ts
- apply setPublicHeaders to config.routes.ts which had no cache headers before

no behaviour change on existing endpoints  same cache preset, just centralised

## Summary

-

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm build`
- [ ] `pnpm exec prisma generate` when schema or generated types changed

## Checklist

- [ ] Linked issue or backlog item
- [ ] No secrets or live credentials added
- [ ] Docs updated if setup or env changed
- [ ] Change is scoped to one problem

closes #43 