### PR TITLE
Add cache config constants for public endpoints

### DIFF
--- a/src/constants/public-endpoint-cache.constants.ts
+++ b/src/constants/public-endpoint-cache.constants.ts
@@ -1,0 +1,26 @@
+/**
+ * Public endpoint cache settings.
+ *
+ * Keep this file limited to lightweight, reusable constants (no runtime logic).
+ */
+export const PUBLIC_ENDPOINT_CACHE_SECONDS = {
+   short: 300,
+   medium: 3600,
+   long: 86400,
+} as const;
+
+export const PUBLIC_ENDPOINT_CACHE_PRESETS = {
+   short: {
+      maxAge: PUBLIC_ENDPOINT_CACHE_SECONDS.short,
+      type: 'public' as const,
+   },
+   medium: {
+      maxAge: PUBLIC_ENDPOINT_CACHE_SECONDS.medium,
+      type: 'public' as const,
+   },
+   long: {
+      maxAge: PUBLIC_ENDPOINT_CACHE_SECONDS.long,
+      type: 'public' as const,
+   },
+} as const;
+

--- a/src/middlewares/cache-control.middleware.ts
+++ b/src/middlewares/cache-control.middleware.ts
@@ -1,5 +1,6 @@
 // src/middlewares/cache-control.middleware.ts
 import { Request, Response, NextFunction } from 'express';
+import { PUBLIC_ENDPOINT_CACHE_PRESETS } from '../constants/public-endpoint-cache.constants';
 
 /**
  * Cache control options for different types of endpoints.
@@ -90,17 +91,17 @@ export const CachePresets = {
    /**
     * Short cache for frequently updated public data (5 minutes)
     */
-   publicShort: { maxAge: 300, type: 'public' as const },
+   publicShort: PUBLIC_ENDPOINT_CACHE_PRESETS.short,
 
    /**
     * Medium cache for moderately stable public data (1 hour)
     */
-   publicMedium: { maxAge: 3600, type: 'public' as const },
+   publicMedium: PUBLIC_ENDPOINT_CACHE_PRESETS.medium,
 
    /**
     * Long cache for stable public data (24 hours)
     */
-   publicLong: { maxAge: 86400, type: 'public' as const },
+   publicLong: PUBLIC_ENDPOINT_CACHE_PRESETS.long,
 
    /**
     * Private cache for user-specific data (5 minutes)

--- a/src/modules/creators/creators.routes.ts
+++ b/src/modules/creators/creators.routes.ts
@@ -1,9 +1,7 @@
 import { Router } from 'express';
 import { httpListCreators } from './creators.controllers';
-import {
-   cacheControl,
-   CachePresets,
-} from '../../middlewares/cache-control.middleware';
+import { cacheControl } from '../../middlewares/cache-control.middleware';
+import { PUBLIC_ENDPOINT_CACHE_PRESETS } from '../../constants/public-endpoint-cache.constants';
 
 const creatorsRouter = Router();
 
@@ -15,7 +13,7 @@ const creatorsRouter = Router();
  */
 creatorsRouter.get(
    '/',
-   cacheControl(CachePresets.publicShort),
+   cacheControl(PUBLIC_ENDPOINT_CACHE_PRESETS.short),
    httpListCreators
 );
 


### PR DESCRIPTION
Closes #37 


Summary
Added PUBLIC_ENDPOINT_CACHE_PRESETS (and PUBLIC_ENDPOINT_CACHE_SECONDS) in src/constants/public-endpoint-cache.constants.ts as a single shared source for public endpoint cache settings.
Updated public creators route to use the shared constants, and wired middleware CachePresets.public* to reference them (no runtime logic moved).

Testing
[x] pnpm lint
[x] pnpm build
[x] pnpm exec prisma generate

Checklist
[x] Linked issue or backlog item: #37
[x] No secrets or live credentials added
[x] Docs updated if setup or env changed (not needed)
[x] Change is scoped to one problem