### PR TITLE
feat: implement creator list sort defaults

### DIFF
--- a/src/constants/creator-list-sort.constants.ts
+++ b/src/constants/creator-list-sort.constants.ts
@@ -1,0 +1,5 @@
+/** Default sort field used by creator list handlers. */
+export const DEFAULT_CREATOR_LIST_SORT = 'createdAt' as const;
+
+/** Default sort order used by creator list handlers. */
+export const DEFAULT_CREATOR_LIST_ORDER = 'desc' as const;

--- a/src/modules/creator/creator.utils.ts
+++ b/src/modules/creator/creator.utils.ts
@@ -1,5 +1,9 @@
 // src/modules/creator/creator.utils.ts
 import { Prisma } from '@prisma/client';
+import {
+   DEFAULT_CREATOR_LIST_ORDER,
+   DEFAULT_CREATOR_LIST_SORT,
+} from '../../constants/creator-list-sort.constants';
 
 export type CreatorSortField = 'createdAt' | 'handle' | 'displayName';
 export type SortOrder = 'asc' | 'desc';
@@ -22,11 +26,11 @@ export function parseCreatorSortOptions(
 
    const field = validFields.includes(sortBy as CreatorSortField)
       ? (sortBy as CreatorSortField)
-      : 'createdAt';
+      : DEFAULT_CREATOR_LIST_SORT;
 
    const order = validOrders.includes(sortOrder as SortOrder)
       ? (sortOrder as SortOrder)
-      : 'desc';
+      : DEFAULT_CREATOR_LIST_ORDER;
 
    return { field, order };
 }

--- a/src/modules/creators/creators.schemas.ts
+++ b/src/modules/creators/creators.schemas.ts
@@ -10,6 +10,10 @@ import {
    MIN_PAGE_SIZE,
    MAX_PAGE_SIZE,
 } from '../../constants/pagination.constants';
+import {
+   DEFAULT_CREATOR_LIST_SORT,
+   DEFAULT_CREATOR_LIST_ORDER,
+} from '../../constants/creator-list-sort.constants';
 
 /**
  * Validation schema for creator list query parameters.
@@ -36,8 +40,11 @@ export const CreatorListQuerySchema = z.object({
    }),
 
    // Sorting
-   sort: z.enum(CREATOR_LIST_SORT_OPTIONS).optional().default('createdAt'),
-   order: z.enum(CREATOR_LIST_SORT_ORDERS).optional().default('desc'),
+   sort: z.enum(CREATOR_LIST_SORT_OPTIONS).optional().default(DEFAULT_CREATOR_LIST_SORT),
+   order: z
+      .enum(CREATOR_LIST_SORT_ORDERS)
+      .optional()
+      .default(DEFAULT_CREATOR_LIST_ORDER),
 
    // Filters
    verified: z


### PR DESCRIPTION
## Summary

- Added `src/constants/creator-list-sort.constants.ts` to centralize default creator list sort field/order.
- Updated `src/modules/creator/creator.utils.ts` to use shared defaults instead of inline fallback literals.
- Updated `src/modules/creators/creators.schemas.ts` to use the same shared defaults in Zod query defaults.
- Kept constants module lightweight and logic-free, with sort mapping/validation behavior unchanged.

Closes #39

## Testing
Closes #39

- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] `pnpm exec prisma generate` when schema or generated types changed

## Checklist

- [x] Linked issue or backlog item
- [x] No secrets or live credentials added
- [ ] Docs updated if setup or env changed
- [x] Change is scoped to one problem
