### PR TITLE
feat(creators): add creator list request context helper (closes #88)

### DIFF
--- a/src/modules/creator/creator.controller.ts
+++ b/src/modules/creator/creator.controller.ts
@@ -12,6 +12,7 @@ import { parseCreatorSortOptions } from './creator.utils';
 import { safeIntParam } from '../../utils/query.utils';
 import { parsePublicQuery } from '../../utils/public-query-parse.utils';
 import { wrapPublicCreatorListResponse } from '../creators/public-creator-list-envelope.utils';
+import { buildCreatorListRequestContext } from '../creators/creator-list-context.utils';
 import {
    MIN_PAGE_SIZE,
    MAX_PAGE_SIZE,
@@ -37,7 +38,8 @@ const LegacyCreatorQuerySchema = z.object({
 
 export async function listCreators(req: Request, res: Response) {
    try {
-      const parsed = parsePublicQuery(LegacyCreatorQuerySchema, req.query);
+      const ctx = buildCreatorListRequestContext(req);
+      const parsed = parsePublicQuery(LegacyCreatorQuerySchema, ctx.query);
       if (!parsed.ok) {
          return sendValidationError(res, 'Invalid query parameters', parsed.details);
       }

--- a/src/modules/creators/creator-list-context.utils.ts
+++ b/src/modules/creators/creator-list-context.utils.ts
@@ -1,0 +1,15 @@
+import { Request } from 'express';
+
+export type CreatorListRequestContext = {
+   query: Request['query'];
+};
+
+/**
+ * Build a lightweight request context for creator list handlers.
+ * Keeps the surface small and predictable for public list routes.
+ */
+export const buildCreatorListRequestContext = (
+   req: Request
+): CreatorListRequestContext => ({
+   query: req.query,
+});

--- a/src/modules/creators/creators.controllers.ts
+++ b/src/modules/creators/creators.controllers.ts
@@ -13,6 +13,7 @@ import {
 } from '../../utils/api-response.utils';
 import { parsePublicQuery } from '../../utils/public-query-parse.utils';
 import { buildOffsetPaginationMeta } from '../../utils/pagination.utils';
+import { buildCreatorListRequestContext } from './creator-list-context.utils';
 
 /**
  * Controller for GET /api/v1/creators
@@ -22,8 +23,10 @@ import { buildOffsetPaginationMeta } from '../../utils/pagination.utils';
  */
 export const httpListCreators: AsyncController = async (req, res, next) => {
    try {
+      const ctx = buildCreatorListRequestContext(req);
+
       // Validate query parameters
-      const parsed = parsePublicQuery(CreatorListQuerySchema, req.query);
+      const parsed = parsePublicQuery(CreatorListQuerySchema, ctx.query);
       if (!parsed.ok) {
          return sendValidationError(res, 'Invalid query parameters', parsed.details);
       }


### PR DESCRIPTION
Closes #88 

Summary
add a lightweight helper to build creator list request context
reuse it across public creator list handlers
Details
helper only exposes query to keep behavior minimal and predictable
list handlers now parse queries from the shared context
Testing
Not run (deadline)