### PR TITLE
Feat/creatorlist boundary guard

### DIFF
--- a/src/modules/creator/creator-list-page.guard.test.ts
+++ b/src/modules/creator/creator-list-page.guard.test.ts
@@ -1,0 +1,14 @@
+import { strict as assert } from 'assert';
+import { normalizeCreatorListPage } from './creator-list-page.guard';
+
+function run() {
+   assert.equal(normalizeCreatorListPage(undefined), 1);
+   assert.equal(normalizeCreatorListPage('abc'), 1);
+   assert.equal(normalizeCreatorListPage(-5), 1);
+   assert.equal(normalizeCreatorListPage(999, { max: 100 }), 100);
+   assert.equal(normalizeCreatorListPage(2), 2);
+
+   console.log('creator-list-page.guard tests passed');
+}
+
+run();

--- a/src/modules/creator/creator-list-page.guard.ts
+++ b/src/modules/creator/creator-list-page.guard.ts
@@ -1,0 +1,26 @@
+export type PageGuardOptions = {
+   min?: number;
+   max?: number;
+   default?: number;
+};
+
+/**
+ * Normalize page query values into a safe integer within configured bounds.
+ * Always normalizes — never rejects or performs side effects.
+ */
+export const normalizeCreatorListPage = (
+   page: unknown,
+   options: PageGuardOptions = {}
+): number => {
+   const min = options.min ?? 1;
+   const max = options.max ?? 100;
+   const fallback = options.default ?? 1;
+
+   const parsed = Number(page);
+
+   if (!Number.isInteger(parsed)) return fallback;
+   if (parsed < min) return min;
+   if (parsed > max) return max;
+
+   return parsed;
+};

--- a/src/modules/creator/creator.controller.ts
+++ b/src/modules/creator/creator.controller.ts
@@ -13,6 +13,7 @@ import { safeIntParam } from '../../utils/query.utils';
 import { parsePublicQuery } from '../../utils/public-query-parse.utils';
 import { wrapPublicCreatorListResponse } from '../creators/public-creator-list-envelope.utils';
 import { buildCreatorListRequestContext } from '../creators/creator-list-context.utils';
+import { normalizeCreatorListPage } from './creator-list-page.guard';
 import {
    MIN_PAGE_SIZE,
    MAX_PAGE_SIZE,
@@ -41,9 +42,14 @@ export async function listCreators(req: Request, res: Response) {
       const ctx = buildCreatorListRequestContext(req);
       const parsed = parsePublicQuery(LegacyCreatorQuerySchema, ctx.query);
       if (!parsed.ok) {
-         return sendValidationError(res, 'Invalid query parameters', parsed.details);
+         return sendValidationError(
+            res,
+            'Invalid query parameters',
+            parsed.details
+         );
       }
-      const { page, limit, sortBy, sortOrder } = parsed.data;
+      const { limit, sortBy, sortOrder } = parsed.data;
+      const page = normalizeCreatorListPage(parsed.data.page);
 
       const sort = parseCreatorSortOptions(sortBy, sortOrder);
 


### PR DESCRIPTION
## Summary
Adds a reusable guard to normalize creator list page values in public endpoints.

## Changes
- Introduced `normalizeCreatorListPage` in `creator-list-page.guard.ts`
- Applied the guard in `httpListCreators` to normalize incoming page query values
- Added a minimal unit test for page normalization behavior

## Implementation Details
- Guard is a pure, deterministic function with no side effects
- Invalid or non-integer values fall back to a default page (1)
- Page values are clamped within a safe range (min: 1, max: 100)
- No changes made to pagination logic or response structure

## Testing
- Verified:
  - undefined and non-numeric values default to 1
  - values below minimum normalize to 1
  - values above maximum are clamped
  - valid page values remain unchanged

## Notes
- No breaking changes introduced
- Behavior is consistent and reusable across creator list endpoints

Closes #86