### PR TITLE
feat(creator): normalize empty slug params

### DIFF
--- a/src/modules/creator/creator-profile.schemas.ts
+++ b/src/modules/creator/creator-profile.schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { withCreatorSlugEmptyStringNormalization } from './creator-slug-input.utils';
 
 /**
  * Shared creator profile identifier schema for route params.
@@ -7,11 +8,13 @@ import { z } from 'zod';
  * and keep this centralized for future route extensions.
  */
 export const CreatorProfileParamsSchema = z.object({
-   creatorId: z
-      .string()
-      .trim()
-      .min(1, 'Creator ID is required')
-      .max(128, 'Creator ID is too long'),
+   creatorId: withCreatorSlugEmptyStringNormalization(
+      z
+         .string()
+         .trim()
+         .min(1, 'Creator ID is required')
+         .max(128, 'Creator ID is too long')
+   ),
 });
 
 /**
@@ -50,7 +53,11 @@ export const UpsertCreatorProfileBodySchema = z.object({
       .trim()
       .max(1000, 'Bio must be at most 1000 characters')
       .optional(),
-   avatarUrl: z.string().trim().url('Avatar URL must be a valid URL').optional(),
+   avatarUrl: z
+      .string()
+      .trim()
+      .url('Avatar URL must be a valid URL')
+      .optional(),
    links: z
       .array(
          z.object({

--- a/src/modules/creator/creator-slug-input.utils.ts
+++ b/src/modules/creator/creator-slug-input.utils.ts
@@ -1,0 +1,36 @@
+import { z, ZodTypeAny } from 'zod';
+
+/**
+ * Normalizes creator slug route input before validation.
+ *
+ * Scope is intentionally narrow:
+ * - exact empty-string input becomes `undefined`
+ * - `null` / `undefined` become `undefined`
+ * - all other values pass through unchanged
+ *
+ * This lets creator route schemas treat empty-string slug params the same way
+ * as omitted params without introducing broader slug rewriting behavior.
+ */
+export function normalizeCreatorSlugEmptyString(value: unknown): unknown {
+   if (value === null || value === undefined) {
+      return undefined;
+   }
+
+   if (value === '') {
+      return undefined;
+   }
+
+   return value;
+}
+
+/**
+ * Wraps a Zod schema with {@link normalizeCreatorSlugEmptyString} preprocessing.
+ *
+ * Use for creator route params that may receive slug-shaped input from HTTP
+ * layers before the actual route schema runs.
+ */
+export function withCreatorSlugEmptyStringNormalization<T extends ZodTypeAny>(
+   schema: T
+) {
+   return z.preprocess(normalizeCreatorSlugEmptyString, schema);
+}


### PR DESCRIPTION
## Summary
- add a narrow helper that normalizes empty-string creator slug input before route validation
- reuse that helper directly in the creator profile params schema
- keep behavior predictable by only converting exact empty-string values to undefined

## Verification
- `pnpm build`
- `pnpm exec eslint src/modules/creator/creator-slug-input.utils.ts src/modules/creator/creator-profile.schemas.ts`
- `pnpm exec ts-node --transpile-only -e "const { CreatorProfileParamsSchema } = require('./src/modules/creator/creator-profile.schemas'); const empty = CreatorProfileParamsSchema.safeParse({ creatorId: '' }); const valid = CreatorProfileParamsSchema.safeParse({ creatorId: 'creator-slug' }); console.log(JSON.stringify({ emptySuccess: empty.success, emptyIssues: empty.success ? [] : empty.error.issues.map((issue) => ({ path: issue.path.join('.'), message: issue.message })), validSuccess: valid.success, validValue: valid.success ? valid.data.creatorId : null }, null, 2));"`

Closes #84
