### PR TITLE
feat: add public creator query key constants (#87)

### DIFF
--- a/src/constants/creator-public-query.constants.ts
+++ b/src/constants/creator-public-query.constants.ts
@@ -1,0 +1,8 @@
+export const CREATOR_PUBLIC_QUERY_KEYS = {
+  CREATOR_ID: "creatorId",
+  CREATOR_ADDRESS: "creatorAddress",
+  USERNAME: "username",
+} as const;
+
+export type CreatorPublicQueryKey =
+  (typeof CREATOR_PUBLIC_QUERY_KEYS)[keyof typeof CREATOR_PUBLIC_QUERY_KEYS];

--- a/src/utils/creator-public-query.util.ts
+++ b/src/utils/creator-public-query.util.ts
@@ -1,0 +1,9 @@
+import { CREATOR_PUBLIC_QUERY_KEYS } from "../constants/creator-public-query.constants";
+
+export const parseCreatorPublicQuery = (query: Record<string, any>) => {
+  return {
+    creatorId: query[CREATOR_PUBLIC_QUERY_KEYS.CREATOR_ID],
+    creatorAddress: query[CREATOR_PUBLIC_QUERY_KEYS.CREATOR_ADDRESS],
+    username: query[CREATOR_PUBLIC_QUERY_KEYS.USERNAME],
+  };
+};


### PR DESCRIPTION

Summary:
Added shared constants for public creator query parameter keys.

Changes:
- Introduced CREATOR_PUBLIC_QUERY_KEYS in constants
- Added parsing utility for consistent query handling

Acceptance Criteria:
- Query keys live in a shared constants location 
- Parsing helpers can import the constants directly 
- Naming is clearly scoped to public creator queries  closes #87 