### PR TITLE
fix(creator): guard empty slug params consistently

### DIFF
--- a/src/modules/creator/creator-profile.schemas.test.ts
+++ b/src/modules/creator/creator-profile.schemas.test.ts
@@ -1,0 +1,47 @@
+import { strict as assert } from 'assert';
+import { CreatorProfileParamsSchema } from './creator-profile.schemas';
+
+function run() {
+   const emptySlugResult = CreatorProfileParamsSchema.safeParse({
+      creatorId: '',
+   });
+   assert.equal(emptySlugResult.success, false);
+   assert.deepEqual(
+      emptySlugResult.success ? [] : emptySlugResult.error.issues,
+      [
+         {
+            code: 'invalid_type',
+            expected: 'string',
+            received: 'undefined',
+            path: ['creatorId'],
+            message: 'Creator ID is required',
+         },
+      ]
+   );
+
+   const whitespaceSlugResult = CreatorProfileParamsSchema.safeParse({
+      creatorId: '   ',
+   });
+   assert.equal(whitespaceSlugResult.success, false);
+   assert.deepEqual(
+      whitespaceSlugResult.success ? [] : whitespaceSlugResult.error.issues,
+      [
+         {
+            code: 'invalid_type',
+            expected: 'string',
+            received: 'undefined',
+            path: ['creatorId'],
+            message: 'Creator ID is required',
+         },
+      ]
+   );
+
+   const validSlugResult = CreatorProfileParamsSchema.safeParse({
+      creatorId: 'alice',
+   });
+   assert.equal(validSlugResult.success, true);
+
+   console.log('creator-profile.schemas tests passed');
+}
+
+run();

--- a/src/modules/creator/creator-profile.schemas.ts
+++ b/src/modules/creator/creator-profile.schemas.ts
@@ -10,7 +10,7 @@ import { withCreatorSlugEmptyStringNormalization } from './creator-slug-input.ut
 export const CreatorProfileParamsSchema = z.object({
    creatorId: withCreatorSlugEmptyStringNormalization(
       z
-         .string()
+         .string({ required_error: 'Creator ID is required' })
          .trim()
          .min(1, 'Creator ID is required')
          .max(128, 'Creator ID is too long')

--- a/src/modules/creator/creator-slug-input.utils.ts
+++ b/src/modules/creator/creator-slug-input.utils.ts
@@ -16,7 +16,7 @@ export function normalizeCreatorSlugEmptyString(value: unknown): unknown {
       return undefined;
    }
 
-   if (value === '') {
+   if (typeof value === 'string' && value.trim() === '') {
       return undefined;
    }
 


### PR DESCRIPTION
## Summary
- normalize empty and whitespace-only creator slug params before deeper schema handling
- return the same `Creator ID is required` validation error for empty-like creator slug input
- add a focused schema regression test for empty, whitespace-only, and valid creator IDs

## Root Cause
The creator slug preprocessing only treated the exact empty string as missing input. Whitespace-only route params were left to deeper validation, and exact empty strings surfaced a generic Zod `Required` error instead of the creator-specific validation message.

## Testing
- pnpm exec ts-node src/modules/creator/creator-profile.schemas.test.ts
- pnpm exec ts-node src/modules/creator/creator-list-page.guard.test.ts

Closes #80 
