### PR TITLE
feat/Add creator public route name constants

### DIFF
--- a/src/constants/creator-public-cache.constants.ts
+++ b/src/constants/creator-public-cache.constants.ts
@@ -4,6 +4,7 @@
  * Reuses shared TTLs from {@link PUBLIC_ENDPOINT_CACHE_SECONDS} where appropriate.
  */
 import { PUBLIC_ENDPOINT_CACHE_SECONDS } from './public-endpoint-cache.constants';
+import { CREATOR_PUBLIC_ROUTE_NAMES } from './creator-public-routes.constants';
 
 /**
  * Max-age (seconds) for public creator GET responses (list, profile, stats).
@@ -18,15 +19,15 @@ const publicReadSeconds = CREATOR_PUBLIC_ROUTE_CACHE_MAX_AGE_SECONDS.publicRead;
  * Options for {@link cacheControl} on creator public routes.
  */
 export const CREATOR_PUBLIC_ROUTE_CACHE_PRESETS = {
-   creatorList: {
+   [CREATOR_PUBLIC_ROUTE_NAMES.LIST]: {
       maxAge: publicReadSeconds,
       type: 'public' as const,
    },
-   creatorStats: {
+   [CREATOR_PUBLIC_ROUTE_NAMES.GET_STATS]: {
       maxAge: publicReadSeconds,
       type: 'public' as const,
    },
-   creatorProfile: {
+   [CREATOR_PUBLIC_ROUTE_NAMES.GET_PROFILE]: {
       maxAge: publicReadSeconds,
       type: 'public' as const,
    },

--- a/src/constants/creator-public-routes.constants.ts
+++ b/src/constants/creator-public-routes.constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared route name constants for creator-facing public API endpoints.
+ *
+ * These constants provide stable identifiers for public creator routes,
+ * allowing related modules (controllers, tests, client-side) to reference
+ * routes by name instead of hardcoded strings.
+ */
+export const CREATOR_PUBLIC_ROUTE_NAMES = {
+   /** GET /api/v1/creators - Paginated list of creators */
+   LIST: 'creators:list',
+   /** GET /api/v1/creators/:creatorId/profile - Public profile details */
+   GET_PROFILE: 'creators:profile:get',
+   /** PUT /api/v1/creators/:creatorId/profile - Upsert profile (scaffold) */
+   UPSERT_PROFILE: 'creators:profile:upsert',
+   /** GET /api/v1/creators/:creatorId/stats - Public creator stats */
+   GET_STATS: 'creators:stats:get',
+} as const;

--- a/src/modules/creator/creator.routes.ts
+++ b/src/modules/creator/creator.routes.ts
@@ -8,6 +8,7 @@ import {
 import { ROOT as CREATORS_ROOT } from '../../constants/creator.constants';
 import { cacheControl } from '../../middlewares/cache-control.middleware';
 import { CREATOR_PUBLIC_ROUTE_CACHE_PRESETS } from '../../constants/creator-public-cache.constants';
+import { CREATOR_PUBLIC_ROUTE_NAMES } from '../../constants/creator-public-routes.constants';
 
 const router = Router();
 
@@ -29,7 +30,7 @@ const router = Router();
  */
 router.get(
    CREATORS_ROOT,
-   cacheControl(CREATOR_PUBLIC_ROUTE_CACHE_PRESETS.creatorList),
+   cacheControl(CREATOR_PUBLIC_ROUTE_CACHE_PRESETS[CREATOR_PUBLIC_ROUTE_NAMES.LIST]),
    listCreators
 );
 
@@ -40,7 +41,7 @@ router.get(
  */
 router.get(
    '/:creatorId/profile',
-   cacheControl(CREATOR_PUBLIC_ROUTE_CACHE_PRESETS.creatorProfile),
+   cacheControl(CREATOR_PUBLIC_ROUTE_CACHE_PRESETS[CREATOR_PUBLIC_ROUTE_NAMES.GET_PROFILE]),
    getCreatorProfileHandler
 );
 

--- a/src/modules/creators/creators.routes.ts
+++ b/src/modules/creators/creators.routes.ts
@@ -1,7 +1,8 @@
 import { Router } from 'express';
-import { httpListCreators } from './creators.controllers';
+import { httpListCreators, httpGetCreatorStats } from './creators.controllers';
 import { cacheControl } from '../../middlewares/cache-control.middleware';
 import { CREATOR_PUBLIC_ROUTE_CACHE_PRESETS } from '../../constants/creator-public-cache.constants';
+import { CREATOR_PUBLIC_ROUTE_NAMES } from '../../constants/creator-public-routes.constants';
 
 const creatorsRouter = Router();
 
@@ -13,8 +14,20 @@ const creatorsRouter = Router();
  */
 creatorsRouter.get(
    '/',
-   cacheControl(CREATOR_PUBLIC_ROUTE_CACHE_PRESETS.creatorList),
+   cacheControl(CREATOR_PUBLIC_ROUTE_CACHE_PRESETS[CREATOR_PUBLIC_ROUTE_NAMES.LIST]),
    httpListCreators
+);
+
+/**
+ * GET /api/v1/creators/:id/stats
+ *
+ * Get public stats for a specific creator.
+ * Public endpoint with 5-minute cache.
+ */
+creatorsRouter.get(
+   '/:id/stats',
+   cacheControl(CREATOR_PUBLIC_ROUTE_CACHE_PRESETS[CREATOR_PUBLIC_ROUTE_NAMES.GET_STATS]),
+   httpGetCreatorStats
 );
 
 export default creatorsRouter;


### PR DESCRIPTION
## Summary
I have added the creator public route name constants and integrated them into the codebase.
-
Closed: #74 
## Testing

- [ x] `pnpm lint`
- [x ] `pnpm build`
- [ x] `pnpm exec prisma generate` when schema or generated types changed

## Checklist

- [x ] Linked issue or backlog item
- [ x] No secrets or live credentials added
- [ x] Docs updated if setup or env changed
- [x ] Change is scoped to one problem
