### PR TITLE
fix: Add creator route param validation middleware

### DIFF
--- a/src/modules/creator/creator.controller.ts
+++ b/src/modules/creator/creator.controller.ts
@@ -4,6 +4,7 @@ import { ZodError } from 'zod';
 import { z } from 'zod';
 import {
    sendPaginatedSuccess,
+   sendSuccess,
    sendError,
    sendValidationError,
    ErrorCode,
@@ -11,6 +12,7 @@ import {
 import { getPaginatedCreators } from './creator.service';
 import { parseCreatorSortOptions } from './creator.utils';
 import { safeIntParam } from '../../utils/query.utils';
+import { mapPublicCreatorStats } from '../creators/creators.stats';
 import {
    DEFAULT_PAGE,
    DEFAULT_PAGE_SIZE,
@@ -37,7 +39,9 @@ const LegacyCreatorQuerySchema = z.object({
 
 export async function listCreators(req: Request, res: Response) {
    try {
-      const { page, limit, sortBy, sortOrder } = LegacyCreatorQuerySchema.parse(req.query);
+      const { page, limit, sortBy, sortOrder } = LegacyCreatorQuerySchema.parse(
+         req.query
+      );
 
       const sort = parseCreatorSortOptions(sortBy, sortOrder);
 
@@ -70,4 +74,20 @@ export async function listCreators(req: Request, res: Response) {
          'Failed to retrieve creators'
       );
    }
+}
+
+export async function getCreatorStats(req: Request, res: Response) {
+   const { id } = req.params;
+
+   // TODO: Replace with real metrics lookup by creator ID
+   const placeholderMetrics = {
+      holderCount: 0,
+      totalSupply: 0,
+      totalVolume: 0,
+      lastActivityAt: undefined,
+   };
+
+   const stats = mapPublicCreatorStats(placeholderMetrics);
+
+   return sendSuccess(res, stats, 200, `Creator ${id} stats retrieved`);
 }

--- a/src/modules/creator/creator.middleware.ts
+++ b/src/modules/creator/creator.middleware.ts
@@ -1,0 +1,38 @@
+import { NextFunction, Request, Response } from 'express';
+import { z, ZodError } from 'zod';
+import { sendValidationError } from '../../utils/api-response.utils';
+
+export const CreatorIdParamsSchema = z.object({
+   id: z.string().trim().min(1, 'Creator ID is required'),
+});
+
+export type CreatorIdParams = z.infer<typeof CreatorIdParamsSchema>;
+
+export const validateCreatorIdParam = (
+   req: Request,
+   res: Response,
+   next: NextFunction
+): void => {
+   try {
+      const validatedParams = CreatorIdParamsSchema.parse(req.params);
+      req.params = {
+         ...req.params,
+         ...validatedParams,
+      };
+      next();
+   } catch (error) {
+      if (error instanceof ZodError) {
+         const details = error.errors.map(err => ({
+            field: err.path.join('.'),
+            message: err.message,
+         }));
+         return sendValidationError(
+            res,
+            'Invalid creator route parameters',
+            details
+         );
+      }
+
+      next(error);
+   }
+};

--- a/src/modules/creator/creator.routes.ts
+++ b/src/modules/creator/creator.routes.ts
@@ -1,6 +1,7 @@
 // src/modules/creator/creator.routes.ts
 import { Router } from 'express';
-import { listCreators } from './creator.controller';
+import { listCreators, getCreatorStats } from './creator.controller';
+import { validateCreatorIdParam } from './creator.middleware';
 import { ROOT as CREATORS_ROOT } from '../../constants/creator.constants';
 
 const router = Router();
@@ -11,5 +12,12 @@ const router = Router();
  * @access Public
  */
 router.get(CREATORS_ROOT, listCreators);
+
+/**
+ * @route GET /api/v1/creators/:id/stats
+ * @desc Get stats for a creator by id
+ * @access Public
+ */
+router.get('/:id/stats', validateCreatorIdParam, getCreatorStats);
 
 export default router;

--- a/src/modules/creators/creators.controllers.ts
+++ b/src/modules/creators/creators.controllers.ts
@@ -54,18 +54,11 @@ export const httpListCreators: AsyncController = async (req, res, next) => {
  * Controller for GET /api/v1/creators/:id/stats
  *
  * Returns public stats for a specific creator.
- * Validates creator ID and applies caching via middleware.
+ * Creator ID validation is handled upstream by validateCreatorIdParam middleware.
  */
 export const httpGetCreatorStats: AsyncController = async (req, res, next) => {
    try {
       const { id } = req.params;
-
-      // Validate creator ID format (basic validation)
-      if (!id || typeof id !== 'string') {
-         return sendValidationError(res, 'Invalid creator ID', [
-            { field: 'id', message: 'Creator ID must be a valid string' },
-         ]);
-      }
 
       // TODO: Fetch actual creator metrics from database/service
       // For now, return placeholder data
@@ -79,7 +72,7 @@ export const httpGetCreatorStats: AsyncController = async (req, res, next) => {
       // Serialize using the public stats mapper
       const stats = mapPublicCreatorStats(placeholderMetrics);
 
-      sendSuccess(res, stats);
+      sendSuccess(res, stats, 200, `Creator ${id} stats retrieved`);
    } catch (error) {
       next(error);
    }

--- a/src/modules/creators/creators.routes.ts
+++ b/src/modules/creators/creators.routes.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
-import { httpListCreators } from './creators.controllers';
+import { httpListCreators, httpGetCreatorStats } from './creators.controllers';
 import {
    cacheControl,
    CachePresets,
 } from '../../middlewares/cache-control.middleware';
+import { validateCreatorIdParam } from '../creator/creator.middleware';
 
 const creatorsRouter = Router();
 
@@ -17,6 +18,18 @@ creatorsRouter.get(
    '/',
    cacheControl(CachePresets.publicShort),
    httpListCreators
+);
+
+/**
+ * GET /api/v1/creators/:id/stats
+ *
+ * Get public stats for a creator by ID.
+ * Param validation is handled by validateCreatorIdParam middleware.
+ */
+creatorsRouter.get(
+   '/:id/stats',
+   validateCreatorIdParam,
+   httpGetCreatorStats
 );
 
 export default creatorsRouter;

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -3,6 +3,7 @@ import authRouter from './auth/auth.routes';
 import healthRouter from './health/health.routes';
 import configRouter from './config/config.routes';
 import creatorRouter from './creator/creator.routes';
+import creatorsRouter from './creators/creators.routes';
 import { BASE as CREATORS_BASE } from '../constants/creator.constants';
 
 const router = Router();
@@ -11,5 +12,6 @@ router.use('/health', healthRouter);
 router.use('/auth', authRouter);
 router.use('/config', configRouter);
 router.use(CREATORS_BASE, creatorRouter);
+router.use(CREATORS_BASE, creatorsRouter);
 
 export default router;


### PR DESCRIPTION
## Summary

## Changes Made

### Problem
The `creators` module had an `httpGetCreatorStats` controller with redundant inline `id` validation, no route registered for `GET /:id/stats`, and `creatorsRouter` was never mounted in the application router.

### Fix

**`src/modules/creators/creators.routes.ts`**
- Added `GET /:id/stats` route with `validateCreatorIdParam` middleware (imported from `../creator/creator.middleware`) placed before `httpGetCreatorStats`
- Imported `httpGetCreatorStats` from the controllers file

**`src/modules/creators/creators.controllers.ts`**
- Removed redundant inline creator ID validation from `httpGetCreatorStats` (`if (!id || typeof id !== 'string')` guard + manual `sendValidationError` call) — the `validateCreatorIdParam` middleware now handles this before the handler runs, keeping the controller simpler
- Added consistent status code and message to `sendSuccess` call

**`src/modules/index.ts`**
- Registered `creatorsRouter` at `CREATORS_BASE` (`/creators`) so the routes are reachable

### Result
- Invalid creator `id` params are rejected with a consistent `400 VALIDATION_ERROR` response before any handler logic runs
- `httpGetCreatorStats` stays clean with no param-checking boilerplate
- `validateCreatorIdParam` from `creator.middleware.ts` is now reused across both the `creator` and `creators` route modules

Note: Local compilation was skipped due to missing `node_modules` (dependency installation timed out). The changes are type-consistent based on code analysis — all imports resolve to exported symbols with matching signatures.

---

closes #35