### PR TITLE
Add creator route 404 JSON helper

### DIFF
--- a/src/modules/creator/creator-profile.handlers.ts
+++ b/src/modules/creator/creator-profile.handlers.ts
@@ -5,6 +5,7 @@ import {
    sendValidationError,
    ErrorCode,
 } from '../../utils/api-response.utils';
+import { sendCreatorNotFound } from './creator.utils';
 import {
    CreatorProfileParamsSchema,
    UpsertCreatorProfileBodySchema,
@@ -37,6 +38,9 @@ export async function getCreatorProfileHandler(req: Request, res: Response) {
       return sendSuccess(res, profile, 200, 'Creator profile retrieved');
    } catch (error) {
       console.error('Error retrieving creator profile:', error);
+      if (error instanceof Error && error.message === 'Creator not found') {
+         return sendCreatorNotFound(res);
+      }
       return sendError(
          res,
          500,

--- a/src/modules/creator/creator-profile.service.ts
+++ b/src/modules/creator/creator-profile.service.ts
@@ -1,26 +1,35 @@
+import { prisma } from '../../utils/prisma.utils';
 import {
    CreatorProfileReadResponse,
    UpsertCreatorProfileBody,
 } from './creator-profile.schemas';
 
 /**
- * Placeholder profile read service.
- *
- * TODO(accesslayer): Replace this placeholder source with database/indexing-backed
- * reads in a follow-up issue.
+ * Get creator profile by handle.
+ * Throws an error if creator is not found.
  */
 export async function getCreatorProfile(
    creatorId: string
 ): Promise<CreatorProfileReadResponse> {
+   // Check if creator exists
+   const creator = await prisma.creatorProfile.findUnique({
+      where: { handle: creatorId },
+   });
+
+   if (!creator) {
+      throw new Error('Creator not found');
+   }
+
+   // TODO(accesslayer): Replace with actual profile data when ready
    return {
       creatorId,
-      displayName: null,
-      bio: null,
-      avatarUrl: null,
-      links: [],
+      displayName: creator.displayName,
+      bio: creator.bio,
+      avatarUrl: creator.avatarUrl,
+      links: [], // TODO: Add links when schema supports
       metadata: {
-         source: 'placeholder',
-         isProfileComplete: false,
+         source: 'database',
+         isProfileComplete: Boolean(creator.displayName && creator.bio),
       },
    };
 }

--- a/src/modules/creator/creator.utils.ts
+++ b/src/modules/creator/creator.utils.ts
@@ -1,5 +1,7 @@
 // src/modules/creator/creator.utils.ts
 import { Prisma } from '@prisma/client';
+import { Response } from 'express';
+import { sendError, ErrorCode } from '../../utils/api-response.utils';
 import {
    CREATOR_LIST_SORT_FIELDS,
    DEFAULT_CREATOR_LIST_ORDER,
@@ -45,4 +47,12 @@ export function toPrismaOrderBy(
    return {
       [options.field]: options.order,
    };
+}
+
+/**
+ * Send a consistent 404 JSON response for creator not found errors.
+ * Uses the shared NOT_FOUND error code for consistency across creator endpoints.
+ */
+export function sendCreatorNotFound(res: Response): void {
+   sendError(res, 404, ErrorCode.NOT_FOUND, 'Creator not found');
 }


### PR DESCRIPTION
closes #101
- Add sendCreatorNotFound helper in creator.utils.ts for consistent 404 responses
- Update getCreatorProfile service to check database for creator existence
- Update getCreatorProfileHandler to use the helper for not found errors
- Helper uses shared NOT_FOUND error code and consistent message

## Summary

-

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm build`
- [ ] `pnpm exec prisma generate` when schema or generated types changed

## Checklist

- [ ] Linked issue or backlog item
- [ ] No secrets or live credentials added
- [ ] Docs updated if setup or env changed
- [ ] Change is scoped to one problem
