### PR TITLE
feat: add RFC-compatible pagination Link headers to list endpoints

### DIFF
--- a/src/utils/api-response.utils.ts
+++ b/src/utils/api-response.utils.ts
@@ -1,7 +1,9 @@
 // src/utils/api-response.utils.ts
 // Shared API response formatters for consistent client-facing responses.
 
-import { Response } from 'express';
+import { Request, Response } from 'express';
+import { URL } from 'url';
+import { OffsetPaginationMeta } from './pagination.utils';
 
 /**
  * Standard API error response shape.
@@ -106,6 +108,17 @@ export function sendSuccess<T>(
    statusCode = 200,
    message?: string
 ): void {
+   // Emit Link headers if pagination metadata is detected in the response body
+   if (data && typeof data === 'object' && 'meta' in data) {
+      const meta = (data as any).meta;
+      if (meta && typeof meta === 'object') {
+         const linkHeader = getLinkHeader(res.req as Request, meta);
+         if (linkHeader) {
+            res.setHeader('Link', linkHeader);
+         }
+      }
+   }
+
    const body: ApiSuccessResponse<T> = {
       success: true,
       data,
@@ -124,6 +137,11 @@ export function sendPaginatedSuccess<T>(
    statusCode = 200,
    message?: string
 ): void {
+   const linkHeader = getLinkHeader(res.req as Request, meta);
+   if (linkHeader) {
+      res.setHeader('Link', linkHeader);
+   }
+
    const body: PaginatedResponse<T> = {
       success: true,
       data,
@@ -163,4 +181,51 @@ export function sendForbidden(
 
 export function sendConflict(res: Response, message: string): void {
    sendError(res, 409, ErrorCode.CONFLICT, message);
+}
+
+// ── Pagination Link headers ──────────────────────────────────
+
+/**
+ * Generates RFC 5988 compatible Link headers for pagination.
+ */
+function getLinkHeader(
+   req: Request,
+   meta: PaginationMetadata | OffsetPaginationMeta
+): string | null {
+   const protocol = req.protocol;
+   const host = req.get('host');
+   if (!host) return null;
+
+   const fullUrl = `${protocol}://${host}${req.originalUrl}`;
+   const url = new URL(fullUrl);
+   const links: string[] = [];
+
+   if ('page' in meta) {
+      // Page-based pagination
+      if (meta.hasNextPage) {
+         const nextUrl = new URL(url.toString());
+         nextUrl.searchParams.set('page', String(meta.page + 1));
+         links.push(`<${nextUrl.toString()}>; rel="next"`);
+      }
+      if (meta.hasPrevPage) {
+         const prevUrl = new URL(url.toString());
+         prevUrl.searchParams.set('page', String(meta.page - 1));
+         links.push(`<${prevUrl.toString()}>; rel="prev"`);
+      }
+   } else if ('offset' in meta) {
+      // Offset-based pagination
+      if (meta.hasMore) {
+         const nextUrl = new URL(url.toString());
+         nextUrl.searchParams.set('offset', String(meta.offset + meta.limit));
+         links.push(`<${nextUrl.toString()}>; rel="next"`);
+      }
+      if (meta.offset > 0) {
+         const prevUrl = new URL(url.toString());
+         const prevOffset = Math.max(0, meta.offset - meta.limit);
+         prevUrl.searchParams.set('offset', String(prevOffset));
+         links.push(`<${prevUrl.toString()}>; rel="prev"`);
+      }
+   }
+
+   return links.length > 0 ? links.join(', ') : null;
 }


### PR DESCRIPTION
This PR implements RFC 5988 compatible Link headers for paginated API responses. This allows clients to discover the next and previous pages of a list without parsing the response body metadata, following standard REST best practices.

Changes:

Modified api-response.utils.ts to include a Link header generator.
Integrated header emission into sendSuccess (for offset-based lists like /creators) and sendPaginatedSuccess (for page-based lists).
Supported both page/limit and offset/limit pagination patterns.
Reconstructed URLs using the incoming request's protocol, host, and original path to ensure accuracy across environments.
Acceptance Criteria Met:

RFC-compatible headers emitted.
Existing body metadata preserved.
No unrelated file churn.
Build and lint passing.
Closes #134 