### PR TITLE
feat: add readiness probe with DB and cache checks

### DIFF
--- a/src/modules/health/health.controllers.ts
+++ b/src/modules/health/health.controllers.ts
@@ -1,6 +1,16 @@
 import { Request, Response } from 'express';
 import { prisma } from '../../utils/prisma.utils';
 import { envConfig } from '../../config';
+import { PUBLIC_ENDPOINT_CACHE_SECONDS } from '../../constants/public-endpoint-cache.constants';
+
+type CheckStatus = 'ok' | 'fail';
+
+interface ReadinessCheck {
+  name: string;
+  status: CheckStatus;
+  latencyMs?: number;
+  error?: string;
+}
 
 interface HealthStatus {
   success: boolean;
@@ -103,5 +113,42 @@ export const simpleHealthCheck = (_: Request, res: Response): void => {
     success: true,
     message: 'OK',
     timestamp: new Date().toISOString(),
+  });
+};
+
+export const readinessCheck = async (_: Request, res: Response): Promise<void> => {
+  const checks: ReadinessCheck[] = [];
+
+  // DB check
+  const dbStart = Date.now();
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    checks.push({ name: 'database', status: 'ok', latencyMs: Date.now() - dbStart });
+  } catch (err) {
+    checks.push({
+      name: 'database',
+      status: 'fail',
+      error: err instanceof Error ? err.message : 'Unknown error',
+    });
+  }
+
+  // Cache config check — verifies the HTTP cache layer is configured
+  try {
+    const configured = typeof PUBLIC_ENDPOINT_CACHE_SECONDS.short === 'number';
+    if (!configured) throw new Error('Cache config unavailable');
+    checks.push({ name: 'cache', status: 'ok' });
+  } catch (err) {
+    checks.push({
+      name: 'cache',
+      status: 'fail',
+      error: err instanceof Error ? err.message : 'Unknown error',
+    });
+  }
+
+  const ready = checks.every(c => c.status === 'ok');
+  res.status(ready ? 200 : 503).json({
+    ready,
+    timestamp: new Date().toISOString(),
+    checks,
   });
 };

--- a/src/modules/health/health.routes.ts
+++ b/src/modules/health/health.routes.ts
@@ -1,12 +1,15 @@
 import { Router } from 'express';
-import { healthCheck, simpleHealthCheck } from './health.controllers';
+import { healthCheck, simpleHealthCheck, readinessCheck } from './health.controllers';
 
 const router = Router();
 
-// Detailed health check with database connectivity
-router.get('/detailed', healthCheck);
-
-// Simple health check for load balancers
+// Liveness — simple check for load balancers, no dependency probing
 router.get('/', simpleHealthCheck);
+
+// Readiness — checks DB and cache; returns 503 if any critical dep is unavailable
+router.get('/ready', readinessCheck);
+
+// Detailed — full diagnostics including memory, system, and db response time
+router.get('/detailed', healthCheck);
 
 export default router;


### PR DESCRIPTION
Fixes #162

## What changed
- Added `GET /api/v1/health/ready` endpoint checking database and HTTP cache config
- Returns `200` when all dependencies healthy, `503` when any critical dep is unavailable
- Response includes per-check `status`, `latencyMs`, and `error` for operator visibility
- Liveness endpoint (`GET /api/v1/health/`) is unchanged — safe for load balancer keep-alives

## Why
Separating liveness from readiness lets orchestrators (Kubernetes, ECS) distinguish process-alive from ready-to-serve-traffic. A failing DB connection routes traffic away without killing the pod.

## How to test
1. Start server with valid `DATABASE_URL` → `GET /api/v1/health/ready` returns `200` with both checks ok
2. Point `DATABASE_URL` at unreachable host → returns `503` with database fail
3. `GET /api/v1/health/` still returns `200 OK` regardless