### PR TITLE
feat: add per-endpoint CORS override configuration

### DIFF
--- a/src/middlewares/cors.middleware.ts
+++ b/src/middlewares/cors.middleware.ts
@@ -1,9 +1,33 @@
-import cors from 'cors';
+import cors, { CorsOptions } from 'cors';
+import { RequestHandler } from 'express';
 import { appConfig } from '../config';
 
-export const corsMiddleware = () =>
-   cors({
-      // origin: appConfig.allowedOrigins,
-      origin: appConfig.allowedOrigins,
-      credentials: true,
-   });
+const defaultCorsOptions: CorsOptions = {
+   origin: appConfig.allowedOrigins,
+   credentials: true,
+};
+
+/**
+ * Global CORS middleware applied to all routes via app.use().
+ * Uses the allowed origins defined in appConfig.
+ */
+export const corsMiddleware = (): RequestHandler => cors(defaultCorsOptions);
+
+/**
+ * Per-endpoint CORS override. Merges the provided options on top of the
+ * global defaults so only the fields you specify are changed.
+ *
+ * Keep secure defaults (allowedOrigins, credentials: true) unless you have
+ * an explicit reason to override them.
+ *
+ * @example
+ * // Allow a specific third-party origin on one public webhook route
+ * router.post('/webhook', corsOverride({ origin: 'https://partner.example.com', credentials: false }), handler);
+ *
+ * @example
+ * // Expose extra headers on a single endpoint
+ * router.get('/export', corsOverride({ exposedHeaders: ['Content-Disposition'] }), exportHandler);
+ */
+export function corsOverride(options: CorsOptions): RequestHandler {
+   return cors({ ...defaultCorsOptions, ...options });
+}


### PR DESCRIPTION
Fixes #159

## What changed
- Exported `corsOverride(options)` factory from `cors.middleware.ts`
- Merges per-route `CorsOptions` on top of global defaults (allowedOrigins + credentials: true)
- Global `corsMiddleware()` and all existing routes are unchanged
- JSDoc examples show webhook and export-headers use-cases

## Why
Some routes (public webhooks, file exports, partner integrations) need a different CORS policy than the app default. The override merges only what you specify so secure defaults are never accidentally dropped.

## How to test
1. Import `corsOverride` on any route and pass custom options (e.g. `{ origin: '*', credentials: false }`)
2. `OPTIONS` preflight on that route should reflect the override
3. All other routes should still use the global allowed-origins policy