### PR TITLE
feat: add queue depth metrics for indexer workers

### DIFF
--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -3,6 +3,7 @@ import authRouter from './auth/auth.routes';
 import healthRouter from './health/health.routes';
 import configRouter from './config/config.routes';
 import creatorsRouter from './creators/creators.routes';
+import metricsRouter from './metrics/metrics.routes';
 import { BASE as CREATORS_BASE } from '../constants/creator.constants';
 
 const router = Router();
@@ -11,5 +12,6 @@ router.use('/health', healthRouter);
 router.use('/auth', authRouter);
 router.use('/config', configRouter);
 router.use(CREATORS_BASE, creatorsRouter);
+router.use('/metrics', metricsRouter);
 
 export default router;

--- a/src/modules/metrics/metrics.controllers.ts
+++ b/src/modules/metrics/metrics.controllers.ts
@@ -1,0 +1,10 @@
+import { Request, Response } from 'express';
+import { getQueueDepths } from '../../utils/queue-metrics.utils';
+
+export const queueMetrics = (_: Request, res: Response): void => {
+  const queues = getQueueDepths();
+  res.status(200).json({
+    timestamp: new Date().toISOString(),
+    queues,
+  });
+};

--- a/src/modules/metrics/metrics.routes.ts
+++ b/src/modules/metrics/metrics.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { queueMetrics } from './metrics.controllers';
+
+const router = Router();
+
+// Queue depth metrics for all indexer worker queues
+router.get('/queues', queueMetrics);
+
+export default router;

--- a/src/utils/queue-metrics.utils.ts
+++ b/src/utils/queue-metrics.utils.ts
@@ -1,0 +1,45 @@
+/**
+ * Lightweight in-process queue depth registry for indexer workers.
+ *
+ * Each worker calls setQueueDepth() after every poll cycle so the metrics
+ * endpoint always reflects the latest observed depth without a DB query.
+ *
+ * Alerting thresholds (recommended):
+ *   pending  > 500  → warning  (backlog building)
+ *   pending  > 2000 → critical (worker may be stalled)
+ *   failed   > 50   → warning  (retry budget draining)
+ *   failed   > 200  → critical (manual intervention needed)
+ *   dlq      > 0    → warning  (poisoned messages present)
+ */
+
+export type QueueState = 'pending' | 'processing' | 'failed' | 'dlq';
+
+export interface QueueDepthEntry {
+  queue: string;
+  state: QueueState;
+  depth: number;
+  updatedAt: string;
+}
+
+const registry = new Map<string, QueueDepthEntry>();
+
+function key(queue: string, state: QueueState): string {
+  return `${queue}:${state}`;
+}
+
+export function setQueueDepth(queue: string, state: QueueState, depth: number): void {
+  registry.set(key(queue, state), {
+    queue,
+    state,
+    depth,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+export function getQueueDepths(): QueueDepthEntry[] {
+  return Array.from(registry.values());
+}
+
+export function resetQueueMetrics(): void {
+  registry.clear();
+}


### PR DESCRIPTION
Fixes #161

## What changed
- Added `src/utils/queue-metrics.utils.ts` — in-process registry with `setQueueDepth(queue, state, depth)` and `getQueueDepths()`
- Added `GET /api/v1/metrics/queues` endpoint returning per-queue, per-state depth with timestamp
- Documented alerting thresholds in the utility file:
  - pending > 500 → warning; > 2000 → critical
  - failed > 50 → warning; > 200 → critical
  - dlq > 0 → warning

## Why
Operators need visibility into indexer worker backlog without polling the DB. Workers call `setQueueDepth()` after each cycle; the metrics endpoint reflects the latest observed depth instantly.

## How to test
1. Call `setQueueDepth('creator-events', 'pending', 42)` in a test or seed script
2. `GET /api/v1/metrics/queues` should return the entry with queue, state, depth, and updatedAt
3. Calling `setQueueDepth` again with a new depth should update the entry