### PR TITLE
docs: add API route inventory page and link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,5 +174,6 @@ readinessProbe:
 - Read the [README](./README.md) for context.
 - Review the [Backend Domain Model and Endpoint Boundaries](./docs/architecture/domain-boundaries.md).
 - Review the scoped backlog in [docs/open-source/issue-backlog.md](./docs/open-source/issue-backlog.md).
+- View the [API Route Inventory](./docs/api-inventory.md) for a current list of available endpoints.
 - Review [SECURITY.md](./SECURITY.md) before reporting vulnerabilities.
 - Use the issue templates in [`.github/ISSUE_TEMPLATE`](./.github/ISSUE_TEMPLATE) for new scoped work.

--- a/docs/api-inventory.md
+++ b/docs/api-inventory.md
@@ -1,0 +1,86 @@
+# API Route Inventory
+
+This document lists the current HTTP endpoints exposed by the Access Layer Server.
+
+**Base URL:** `/api/v1`
+
+## Health Module
+
+Routes for service availability checks and diagnostics.
+
+| Method | Path | Description |
+| :----- | :--- | :---------- |
+| `GET` | `/health` | Simple liveness check for load balancers and uptime monitors. |
+| `GET` | `/health/ready` | Readiness check that verifies critical dependencies. |
+| `GET` | `/health/detailed` | Detailed diagnostics including system and database status. |
+
+## Auth Module
+
+Authentication and session-related endpoints.
+
+| Method | Path | Description |
+| :----- | :--- | :---------- |
+| `POST` | `/auth/login` | Authenticate a user and return a session response. |
+| `POST` | `/auth/register` | Register a new user account. |
+
+## Config Module
+
+Public bootstrap configuration.
+
+| Method | Path | Description |
+| :----- | :--- | :---------- |
+| `GET` | `/config` | Return public protocol configuration for client startup. |
+
+## Creators Module
+
+Public creator discovery and stats endpoints.
+
+| Method | Path | Description |
+| :----- | :--- | :---------- |
+| `GET` | `/creators` | List creators with pagination and filtering. |
+| `GET` | `/creators/:id/stats` | Return public stats for a specific creator. |
+
+## Activity Module
+
+Public activity feed endpoints.
+
+| Method | Path | Description |
+| :----- | :--- | :---------- |
+| `GET` | `/activity` | Return the public activity feed. |
+
+## Ownership Module
+
+Ownership lookup endpoints.
+
+| Method | Path | Description |
+| :----- | :--- | :---------- |
+| `GET` | `/ownership` | Look up key ownership by owner address or creator ID. |
+
+## Metrics Module
+
+Operational metrics for background work.
+
+| Method | Path | Description |
+| :----- | :--- | :---------- |
+| `GET` | `/metrics/queues` | Return queue depth metrics for worker queues. |
+
+## Admin Module
+
+Restricted administrative endpoints.
+
+| Method | Path | Description |
+| :----- | :--- | :---------- |
+| `PATCH` | `/admin/creators/:id/metadata` | Update creator metadata such as verification state. |
+| `POST` | `/admin/indexer/replay` | Trigger an indexer replay job. |
+
+---
+
+## Root and Miscellaneous
+
+Endpoints outside the `/api/v1` namespace.
+
+| Method | Path | Description |
+| :----- | :--- | :---------- |
+| `GET` | `/` | Redirect to `/api-docs`. |
+| `GET` | `/api-docs` | Interactive API documentation. |
+| `GET` | `/test-email` | Diagnostic endpoint for testing email transport. |


### PR DESCRIPTION
## Summary

Adds an API route inventory documentation page listing current endpoints by module, including method, path, and responsibility. Linked from the README for discoverability.

Closes #193

## Testing

* [x] `pnpm lint`
* [x] `pnpm build`

## Checklist

* [x] Linked issue or backlog item
* [x] No secrets or live credentials added
* [x] Docs updated if setup or env changed
* [x] Change is scoped to one problem
