### PR TITLE
feat: add forbidden/unauthorized response helpers and usage

### DIFF
--- a/src/modules/admin/admin.controllers.ts
+++ b/src/modules/admin/admin.controllers.ts
@@ -1,81 +1,95 @@
 import { AsyncController } from '../../types/auth.types';
-import { sendSuccess, sendValidationError, sendNotFound } from '../../utils/api-response.utils';
+import {
+   sendSuccess,
+   sendValidationError,
+   sendNotFound,
+   sendForbidden,
+} from '../../utils/api-response.utils';
 import { prisma } from '../../utils/prisma.utils';
 import { emitAuditEvent } from '../../utils/audit.utils';
 import { z } from 'zod';
 
 const UpdateCreatorMetadataSchema = z.object({
-  isVerified: z.boolean().optional(),
+   isVerified: z.boolean().optional(),
 });
 
 type UpdateCreatorMetadataInput = z.infer<typeof UpdateCreatorMetadataSchema>;
 
-export const httpUpdateCreatorMetadata: AsyncController = async (req, res, next) => {
-  try {
-    const { id } = req.params as { id: string };
-    const adminIdHeader = req.headers['x-admin-id'];
-    const actorId =
-      typeof adminIdHeader === 'string'
-        ? adminIdHeader
-        : Array.isArray(adminIdHeader)
-          ? adminIdHeader[0]
-          : undefined;
+export const httpUpdateCreatorMetadata: AsyncController = async (
+   req,
+   res,
+   next
+) => {
+   try {
+      const { id } = req.params as { id: string };
+      const adminIdHeader = req.headers['x-admin-id'];
+      const actorId =
+         typeof adminIdHeader === 'string'
+            ? adminIdHeader
+            : Array.isArray(adminIdHeader)
+              ? adminIdHeader[0]
+              : undefined;
 
-    if (!id || !actorId) {
-      return sendValidationError(res, 'Missing required parameters', [
-        { field: 'id', message: 'Creator ID is required' },
-        { field: 'x-admin-id', message: 'Admin ID header is required' },
-      ]);
-    }
-
-    const parsed = UpdateCreatorMetadataSchema.safeParse(req.body);
-    if (!parsed.success) {
-      return sendValidationError(res, 'Invalid request body', [
-        { field: 'body', message: 'Invalid metadata update' },
-      ]);
-    }
-
-    const updates = parsed.data as UpdateCreatorMetadataInput;
-
-    const creator = await prisma.creatorProfile.findUnique({
-      where: { id },
-    });
-
-    if (!creator) {
-      return sendNotFound(res, 'Creator');
-    }
-
-    const previousValues = {
-      isVerified: creator.isVerified,
-    };
-
-    const updated = await prisma.creatorProfile.update({
-      where: { id },
-      data: updates,
-    });
-
-    const changes: Record<string, unknown> = {};
-    Object.entries(updates).forEach(([key, value]) => {
-      if (value !== previousValues[key as keyof typeof previousValues]) {
-        changes[key] = {
-          before: previousValues[key as keyof typeof previousValues],
-          after: value,
-        };
+      if (!actorId) {
+         return sendForbidden(res, 'Admin access required', [
+            { field: 'x-admin-id', message: 'Admin ID header is required' },
+         ]);
       }
-    });
 
-    if (Object.keys(changes).length > 0) {
-      await emitAuditEvent({
-        actor: actorId,
-        action: 'update_creator_metadata',
-        target: 'CreatorProfile',
-        targetId: id,
-        metadata: changes,
+      if (!id) {
+         return sendValidationError(res, 'Missing required parameters', [
+            { field: 'id', message: 'Creator ID is required' },
+         ]);
+      }
+
+      const parsed = UpdateCreatorMetadataSchema.safeParse(req.body);
+      if (!parsed.success) {
+         return sendValidationError(res, 'Invalid request body', [
+            { field: 'body', message: 'Invalid metadata update' },
+         ]);
+      }
+
+      const updates = parsed.data as UpdateCreatorMetadataInput;
+
+      const creator = await prisma.creatorProfile.findUnique({
+         where: { id },
       });
-    }
 
-    sendSuccess(res, updated);
-  } catch (error) {
-    next(error);
-  }
+      if (!creator) {
+         return sendNotFound(res, 'Creator');
+      }
+
+      const previousValues = {
+         isVerified: creator.isVerified,
+      };
+
+      const updated = await prisma.creatorProfile.update({
+         where: { id },
+         data: updates,
+      });
+
+      const changes: Record<string, unknown> = {};
+      Object.entries(updates).forEach(([key, value]) => {
+         if (value !== previousValues[key as keyof typeof previousValues]) {
+            changes[key] = {
+               before: previousValues[key as keyof typeof previousValues],
+               after: value,
+            };
+         }
+      });
+
+      if (Object.keys(changes).length > 0) {
+         await emitAuditEvent({
+            actor: actorId,
+            action: 'update_creator_metadata',
+            target: 'CreatorProfile',
+            targetId: id,
+            metadata: changes,
+         });
+      }
+
+      sendSuccess(res, updated);
+   } catch (error) {
+      next(error);
+   }
 };

--- a/src/utils/api-response.utils.ts
+++ b/src/utils/api-response.utils.ts
@@ -137,16 +137,18 @@ export function sendNotFound(res: Response, resource: string): void {
 
 export function sendUnauthorized(
    res: Response,
-   message = 'Unauthorized access'
+   message = 'Unauthorized access',
+   details?: Array<{ field?: string; message: string }>
 ): void {
-   sendError(res, 401, ErrorCode.UNAUTHORIZED, message);
+   sendError(res, 401, ErrorCode.UNAUTHORIZED, message, details);
 }
 
 export function sendForbidden(
    res: Response,
-   message = 'Access forbidden'
+   message = 'Access forbidden',
+   details?: Array<{ field?: string; message: string }>
 ): void {
-   sendError(res, 403, ErrorCode.FORBIDDEN, message);
+   sendError(res, 403, ErrorCode.FORBIDDEN, message, details);
 }
 
 export function sendConflict(res: Response, message: string): void {

--- a/src/utils/test/api-response.utils.test.ts
+++ b/src/utils/test/api-response.utils.test.ts
@@ -1,0 +1,65 @@
+import { Response } from 'express';
+import {
+   sendForbidden,
+   sendUnauthorized,
+   ErrorCode,
+} from '../api-response.utils';
+
+describe('api-response.utils', () => {
+   let mockResponse: Partial<Response>;
+   let jsonMock: jest.Mock;
+   let statusMock: jest.Mock;
+
+   beforeEach(() => {
+      jsonMock = jest.fn();
+      statusMock = jest.fn().mockReturnValue({ json: jsonMock });
+      mockResponse = {
+         status: statusMock,
+      };
+   });
+
+   describe('sendForbidden', () => {
+      it('should send a 403 response with default message', () => {
+         sendForbidden(mockResponse as Response);
+
+         expect(statusMock).toHaveBeenCalledWith(403);
+         expect(jsonMock).toHaveBeenCalledWith({
+            success: false,
+            error: {
+               code: ErrorCode.FORBIDDEN,
+               message: 'Access forbidden',
+            },
+         });
+      });
+
+      it('should send a 403 response with custom message and details', () => {
+         const details = [{ field: 'role', message: 'Required admin role' }];
+         sendForbidden(mockResponse as Response, 'Custom forbidden', details);
+
+         expect(statusMock).toHaveBeenCalledWith(403);
+         expect(jsonMock).toHaveBeenCalledWith({
+            success: false,
+            error: {
+               code: ErrorCode.FORBIDDEN,
+               message: 'Custom forbidden',
+               details,
+            },
+         });
+      });
+   });
+
+   describe('sendUnauthorized', () => {
+      it('should send a 401 response with default message', () => {
+         sendUnauthorized(mockResponse as Response);
+
+         expect(statusMock).toHaveBeenCalledWith(401);
+         expect(jsonMock).toHaveBeenCalledWith({
+            success: false,
+            error: {
+               code: ErrorCode.UNAUTHORIZED,
+               message: 'Unauthorized access',
+            },
+         });
+      });
+   });
+});


### PR DESCRIPTION
## Summary

Adds standardized helpers for forbidden and unauthorized responses and applies them to admin access checks.

Closes #189

## Changes

* Enhance `sendForbidden` and `sendUnauthorized` to support optional details
* Use `sendForbidden` in admin controller for consistent 403 handling
* Add unit tests for response helpers

## Testing

* [x] `pnpm lint`
* [x] `pnpm build`
* [x] `pnpm jest src/utils/test/api-response.utils.test.ts`

## Notes

* Scoped to response helpers and admin access checks only
* No unrelated file changes included
