### PR TITLE
feat: filter whitespace normalization tests, creator detail include c…

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,7 @@ export const envSchema = z.object({
    ENABLE_REQUEST_LOGGING: z.coerce.boolean().default(true),
    INDEXER_JITTER_FACTOR: z.coerce.number().min(0).max(1).default(0.1),
    BACKGROUND_JOB_LOCK_TTL_MS: z.coerce.number().int().positive().default(300000),
+   CREATOR_LIST_SLOW_QUERY_THRESHOLD_MS: z.coerce.number().int().positive().default(500),
 });
 
 export const envConfig = envSchema.parse(process.env);

--- a/src/constants/creator-detail-include.constants.ts
+++ b/src/constants/creator-detail-include.constants.ts
@@ -1,0 +1,22 @@
+// src/constants/creator-detail-include.constants.ts
+// Centralized default include-fields for creator detail reads.
+// Route and service layers should reference these instead of inlining field lists.
+
+/**
+ * Prisma select fields returned for every creator detail read.
+ * Keeping this centralized ensures route, service, and test layers
+ * stay in sync without duplicating field lists.
+ */
+export const CREATOR_DETAIL_DEFAULT_SELECT = {
+  id: true,
+  handle: true,
+  displayName: true,
+  bio: true,
+  avatarUrl: true,
+  perks: true,
+  isVerified: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+export type CreatorDetailSelectKeys = keyof typeof CREATOR_DETAIL_DEFAULT_SELECT;

--- a/src/modules/creator/creator-profile.service.ts
+++ b/src/modules/creator/creator-profile.service.ts
@@ -3,6 +3,7 @@ import {
    CreatorProfileReadResponse,
    UpsertCreatorProfileBody,
 } from './creator-profile.schemas';
+import { CREATOR_DETAIL_DEFAULT_SELECT } from '../../constants/creator-detail-include.constants';
 
 /**
  * Reads a creator profile from the database.
@@ -16,6 +17,7 @@ export async function getCreatorProfile(
       where: {
          OR: [{ id: creatorId }, { handle: creatorId }],
       },
+      select: CREATOR_DETAIL_DEFAULT_SELECT,
    });
 
    if (!profile) {

--- a/src/modules/creators/creators.filter.test.ts
+++ b/src/modules/creators/creators.filter.test.ts
@@ -1,0 +1,61 @@
+// src/modules/creators/creators.filter.test.ts
+// Unit tests for creator list filter whitespace normalization.
+// Asserts that parseCreatorFilters normalizes inputs consistently with
+// the query parser rules defined in creators.query-string.utils.ts.
+
+import { strict as assert } from 'assert';
+import { parseCreatorFilters } from './creators.filter';
+
+function run() {
+  // --- search: whitespace normalization ---
+
+  // leading/trailing whitespace is trimmed
+  assert.deepEqual(parseCreatorFilters({ search: '  jazz  ' }), { search: 'jazz' });
+
+  // internal whitespace collapses to a single space
+  assert.deepEqual(parseCreatorFilters({ search: 'jazz   musician' }), { search: 'jazz musician' });
+
+  // tabs and newlines are treated as whitespace
+  assert.deepEqual(parseCreatorFilters({ search: '\t jazz \n' }), { search: 'jazz' });
+
+  // whitespace-only input is dropped (no search key in result)
+  assert.deepEqual(parseCreatorFilters({ search: '   ' }), {});
+
+  // empty string is dropped
+  assert.deepEqual(parseCreatorFilters({ search: '' }), {});
+
+  // undefined search is omitted
+  assert.deepEqual(parseCreatorFilters({}), {});
+
+  // normal search passes through unchanged
+  assert.deepEqual(parseCreatorFilters({ search: 'alice' }), { search: 'alice' });
+
+  // --- verified: coercion ---
+
+  assert.deepEqual(parseCreatorFilters({ verified: 'true' }), { verified: true });
+  assert.deepEqual(parseCreatorFilters({ verified: 'false' }), { verified: false });
+  assert.deepEqual(parseCreatorFilters({ verified: true }), { verified: true });
+
+  // --- combined ---
+
+  assert.deepEqual(
+    parseCreatorFilters({ verified: 'true', search: '  bob  ' }),
+    { verified: true, search: 'bob' }
+  );
+
+  // --- unknown keys are rejected ---
+
+  assert.throws(
+    () => parseCreatorFilters({ unknown: 'value' }),
+    /Unsupported creator filter key\(s\): unknown/
+  );
+
+  assert.throws(
+    () => parseCreatorFilters({ verified: 'true', extra: '1' }),
+    /Unsupported creator filter key\(s\): extra/
+  );
+
+  console.log('creators.filter whitespace normalization tests passed');
+}
+
+run();

--- a/src/modules/creators/creators.filter.ts
+++ b/src/modules/creators/creators.filter.ts
@@ -50,9 +50,9 @@ export function parseCreatorFilters(
     }
 
     if (typeof raw.search === 'string') {
-        const trimmed = raw.search.trim();
-        if (trimmed.length > 0) {
-            result.search = trimmed;
+        const normalized = raw.search.trim().replace(/\s+/g, ' ');
+        if (normalized.length > 0) {
+            result.search = normalized;
         }
     }
 

--- a/src/modules/creators/creators.utils.ts
+++ b/src/modules/creators/creators.utils.ts
@@ -5,6 +5,8 @@ import { mapCreatorListSort } from './creators.sort';
 import { serializeCreatorListResponse, CreatorListResponse } from './creators.serializers';
 import { buildOffsetPaginationMeta } from '../../utils/pagination.utils';
 import { normalizeCreatorListSearchTerm } from './creators.search-term.utils';
+import { logger } from '../../utils/logger.utils';
+import { envConfig } from '../../config';
 
 type CreatorListWhere = {
    isVerified?: boolean;
@@ -44,6 +46,7 @@ export async function fetchCreatorList(
    const orderBy = mapCreatorListSort(sort, order);
 
    // Fetch creators and total count in parallel
+   const start = Date.now();
    const [creators, total] = await Promise.all([
       prisma.creatorProfile.findMany({
          where,
@@ -53,6 +56,21 @@ export async function fetchCreatorList(
       }),
       prisma.creatorProfile.count({ where }),
    ]);
+
+   const durationMs = Date.now() - start;
+   if (durationMs > envConfig.CREATOR_LIST_SLOW_QUERY_THRESHOLD_MS) {
+      logger.warn({
+         msg: 'Slow creator list query',
+         durationMs,
+         thresholdMs: envConfig.CREATOR_LIST_SLOW_QUERY_THRESHOLD_MS,
+         sort,
+         order,
+         hasSearch: !!normalizedSearch,
+         hasVerifiedFilter: verified !== undefined,
+         limit,
+         offset,
+      });
+   }
 
    return [creators as unknown as CreatorProfile[], total];
 }

--- a/src/utils/creator-feed-cursor.utils.ts
+++ b/src/utils/creator-feed-cursor.utils.ts
@@ -1,0 +1,63 @@
+// src/utils/creator-feed-cursor.utils.ts
+// Decode and validate creator feed cursors in one place.
+// All feed endpoint paths should use decodeCreatorFeedCursor instead of
+// calling decodeCursor directly, so parse errors are consistent.
+
+import { decodeCursor, CursorChecksumError } from './cursor.utils';
+
+/**
+ * Shape of a decoded creator feed cursor payload.
+ */
+export interface CreatorFeedCursorPayload {
+  /** ISO timestamp used as the pagination anchor */
+  createdAt: string;
+  /** Tiebreaker ID for stable ordering */
+  id: string;
+}
+
+export type CreatorFeedCursorResult =
+  | { ok: true; payload: CreatorFeedCursorPayload }
+  | { ok: false; error: string };
+
+/**
+ * Decode and validate a creator feed cursor string.
+ *
+ * Returns a discriminated union so callers can handle parse errors
+ * without catching exceptions.
+ *
+ * @param raw - Raw cursor string from query params
+ * @returns `{ ok: true, payload }` or `{ ok: false, error }`
+ *
+ * @example
+ * const result = decodeCreatorFeedCursor(req.query.cursor);
+ * if (!result.ok) return sendValidationError(res, result.error);
+ */
+export function decodeCreatorFeedCursor(raw: unknown): CreatorFeedCursorResult {
+  if (raw === undefined || raw === null || raw === '') {
+    return { ok: false, error: 'Cursor is required' };
+  }
+
+  if (typeof raw !== 'string') {
+    return { ok: false, error: 'Cursor must be a string' };
+  }
+
+  let payload: CreatorFeedCursorPayload;
+  try {
+    payload = decodeCursor<CreatorFeedCursorPayload>(raw);
+  } catch (err) {
+    const message =
+      err instanceof CursorChecksumError ? err.message : 'Invalid cursor';
+    return { ok: false, error: message };
+  }
+
+  if (
+    typeof payload.createdAt !== 'string' ||
+    typeof payload.id !== 'string' ||
+    !payload.createdAt ||
+    !payload.id
+  ) {
+    return { ok: false, error: 'Cursor payload is missing required fields' };
+  }
+
+  return { ok: true, payload };
+}


### PR DESCRIPTION
## Summary

Four focused improvements to the creator list and feed subsystems: test coverage for filter whitespace normalization, centralized include-field constants for creator detail reads, a validated cursor decode helper for the creator feed, and a configurable slow query warning log on the creator list path.

---

## Changes

### 1. Filter whitespace normalization tests
`src/modules/creators/creators.filter.test.ts`

Added unit coverage for `parseCreatorFilters` whitespace handling:
- leading/trailing whitespace is trimmed
- internal whitespace collapses to a single space
- whitespace-only input is dropped (no key in result)
- unknown filter keys throw with a descriptive message
- combined `verified` + `search` cases

Also aligned `parseCreatorFilters` to collapse internal whitespace (`/\s+/g → ' '`), matching the behavior of `normalizeCreatorListSearchTerm`.

---

### 2. Centralized creator detail include-field constants
`src/constants/creator-detail-include.constants.ts`
`src/modules/creator/creator-profile.service.ts`

Defined `CREATOR_DETAIL_DEFAULT_SELECT` as a single source of truth for the Prisma select fields returned on every creator detail read. Applied it in `getCreatorProfile` to replace the previously implicit full-row fetch. Response shape is backward compatible.

---

### 3. Creator feed cursor decode helper
`src/utils/creator-feed-cursor.utils.ts`

Added `decodeCreatorFeedCursor(raw)` which wraps the existing `decodeCursor` utility and:
- returns a discriminated union `{ ok: true, payload } | { ok: false, error }` so callers avoid try/catch
- validates that the decoded payload contains the required `createdAt` and `id` fields
- surfaces `CursorChecksumError` messages directly for consistent API error responses

---

### 4. Slow creator list query warning log
`src/config.ts`
`src/modules/creators/creators.utils.ts`

Added `CREATOR_LIST_SLOW_QUERY_THRESHOLD_MS` to the env config schema (default `500`ms). When `fetchCreatorList` exceeds the threshold, a `logger.warn` fires with sanitized metadata:

```
{
  msg: 'Slow creator list query',
  durationMs,
  thresholdMs,
  sort,
  order,
  hasSearch,        // boolean — no raw search term logged
  hasVerifiedFilter,
  limit,
  offset
}
```

Override the threshold via environment variable:
```
CREATOR_LIST_SLOW_QUERY_THRESHOLD_MS=1000
```

---

## Files Changed

| File | Change |
|------|--------|
| `src/modules/creators/creators.filter.test.ts` | new — whitespace normalization tests |
| `src/modules/creators/creators.filter.ts` | fix — collapse internal whitespace in search |
| `src/constants/creator-detail-include.constants.ts` | new — `CREATOR_DETAIL_DEFAULT_SELECT` |
| `src/modules/creator/creator-profile.service.ts` | refactor — use `CREATOR_DETAIL_DEFAULT_SELECT` |
| `src/utils/creator-feed-cursor.utils.ts` | new — `decodeCreatorFeedCursor` helper |
| `src/config.ts` | feat — `CREATOR_LIST_SLOW_QUERY_THRESHOLD_MS` config key |
| `src/modules/creators/creators.utils.ts` | feat — slow query warning log |

---

## Testing

Run existing test suite:
```bash
pnpm test
```

Run filter tests directly:
```bash
node_modules/.bin/jest --testPathPatterns="creators.filter.test" --no-coverage
```

---

## Backward Compatibility

No breaking changes. All response shapes are preserved. The new config key has a safe default.

## Linked Issues

Close #235
Close #236
Close #234
Close #233

