### PR TITLE
Centralize creator feed sort option constants

### DIFF
--- a/src/constants/creator-list-sort.constants.ts
+++ b/src/constants/creator-list-sort.constants.ts
@@ -11,8 +11,15 @@ export const CREATOR_LIST_SORT_FIELDS = [
 
 export type CreatorListSortField = (typeof CREATOR_LIST_SORT_FIELDS)[number];
 
+/**
+ * Allowed sort orders for creator list endpoints.
+ */
+export const CREATOR_LIST_SORT_ORDERS = ['asc', 'desc'] as const;
+
+export type CreatorListSortOrder = (typeof CREATOR_LIST_SORT_ORDERS)[number];
+
 /** Default sort field used by creator list handlers. */
 export const DEFAULT_CREATOR_LIST_SORT: CreatorListSortField = 'createdAt';
 
 /** Default sort order used by creator list handlers. */
-export const DEFAULT_CREATOR_LIST_ORDER = 'desc' as const;
+export const DEFAULT_CREATOR_LIST_ORDER: CreatorListSortOrder = 'desc';

--- a/src/modules/creator/creator.utils.ts
+++ b/src/modules/creator/creator.utils.ts
@@ -4,13 +4,15 @@ import { resolveSlugCollision } from '../../utils/slug.utils';
 import { prisma } from '../../utils/prisma.utils';
 import {
    CREATOR_LIST_SORT_FIELDS,
+   CREATOR_LIST_SORT_ORDERS,
    DEFAULT_CREATOR_LIST_ORDER,
    DEFAULT_CREATOR_LIST_SORT,
    type CreatorListSortField,
+   type CreatorListSortOrder,
 } from '../../constants/creator-list-sort.constants';
 
 export type CreatorSortField = CreatorListSortField;
-export type SortOrder = 'asc' | 'desc';
+export type SortOrder = CreatorListSortOrder;
 
 export interface CreatorSortOptions {
    field: CreatorSortField;
@@ -25,13 +27,11 @@ export function parseCreatorSortOptions(
    sortBy?: string,
    sortOrder?: string
 ): CreatorSortOptions {
-   const validOrders: SortOrder[] = ['asc', 'desc'];
-
    const field = CREATOR_LIST_SORT_FIELDS.includes(sortBy as CreatorSortField)
       ? (sortBy as CreatorSortField)
       : DEFAULT_CREATOR_LIST_SORT;
 
-   const order = validOrders.includes(sortOrder as SortOrder)
+   const order = CREATOR_LIST_SORT_ORDERS.includes(sortOrder as SortOrder)
       ? (sortOrder as SortOrder)
       : DEFAULT_CREATOR_LIST_ORDER;
 

--- a/src/modules/creators/creators.sort-direction.parse.ts
+++ b/src/modules/creators/creators.sort-direction.parse.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 import {
    CREATOR_LIST_SORT_ORDERS,
+   DEFAULT_CREATOR_LIST_ORDER,
    type CreatorListSortOrder,
-} from './creators.sort';
-import { DEFAULT_CREATOR_LIST_ORDER } from '../../constants/creator-list-sort.constants';
+} from '../../constants/creator-list-sort.constants';
 import { normalizeCreatorListQueryStringValue } from './creators.query-string.utils';
 
 const creatorListSortDirectionEnum = z.enum(CREATOR_LIST_SORT_ORDERS);

--- a/src/modules/creators/creators.sort.ts
+++ b/src/modules/creators/creators.sort.ts
@@ -2,6 +2,7 @@ import { Prisma } from '@prisma/client';
 import {
    CREATOR_LIST_SORT_FIELDS,
    type CreatorListSortField,
+   type CreatorListSortOrder,
 } from '../../constants/creator-list-sort.constants';
 
 /**
@@ -10,10 +11,8 @@ import {
  */
 export const CREATOR_LIST_SORT_OPTIONS = CREATOR_LIST_SORT_FIELDS;
 
-export const CREATOR_LIST_SORT_ORDERS = ['asc', 'desc'] as const;
-
 export type CreatorListSortOption = CreatorListSortField;
-export type CreatorListSortOrder = (typeof CREATOR_LIST_SORT_ORDERS)[number];
+export { type CreatorListSortOrder };
 
 const CREATOR_LIST_SORT_FIELD_MAP: Record<
    CreatorListSortOption,


### PR DESCRIPTION
- Add CREATOR_LIST_SORT_ORDERS and CreatorListSortOrder type to constants module
- Update creators.sort.ts to import from constants
- Update creators.sort-direction.parse.ts to import from constants
- Update creator.utils.ts to use centralized constant instead of inline array

Closes #228