### PR TITLE
feat: add request query signature helper for cache diagnostics (#223)

### DIFF
--- a/src/utils/query-normalization-debug.utils.ts
+++ b/src/utils/query-normalization-debug.utils.ts
@@ -1,8 +1,5 @@
-// src/utils/query-normalization-debug.utils.ts
-// Debug helper for emitting normalized query snapshots for diagnostics.
-// Only active when logger is set to debug level to avoid performance impact.
-
 import { logger } from './logger.utils';
+import { buildQuerySignature } from './querySignature';
 
 /**
  * Fields that should be sanitized to avoid leaking sensitive data in debug logs.
@@ -82,6 +79,8 @@ export interface QueryNormalizationSnapshot {
    timestamp: string;
    /** Optional context label for identifying the query source */
    context?: string;
+   /** Query signature for cache diagnostics */
+   querySignature?: string;
 }
 
 /**
@@ -107,11 +106,17 @@ export interface QueryNormalizationSnapshot {
  * });
  */
 export function emitQueryNormalizationDebug(
-   snapshot: Omit<QueryNormalizationSnapshot, 'timestamp'>
+   snapshot: Omit<QueryNormalizationSnapshot, 'timestamp' | 'querySignature'>
 ): void {
    // Only emit debug logs if logger is at debug level
    if (!logger.isLevelEnabled('debug')) {
       return;
+   }
+
+   // Build query signature if raw query is an object
+   let querySignature: string | undefined;
+   if (typeof snapshot.raw === 'object' && snapshot.raw !== null && !Array.isArray(snapshot.raw)) {
+      querySignature = buildQuerySignature(snapshot.raw as Record<string, unknown>);
    }
 
    const sanitizedSnapshot: QueryNormalizationSnapshot = {
@@ -121,6 +126,7 @@ export function emitQueryNormalizationDebug(
       errors: snapshot.errors,
       timestamp: new Date().toISOString(),
       context: snapshot.context,
+      querySignature,
    };
 
    logger.debug({
@@ -149,7 +155,7 @@ export function emitQueryNormalizationDebug(
  * });
  */
 export function createQueryDebugEmitter(context: string) {
-   return (snapshot: Omit<QueryNormalizationSnapshot, 'timestamp' | 'context'>) => {
+   return (snapshot: Omit<QueryNormalizationSnapshot, 'timestamp' | 'context' | 'querySignature'>) => {
       emitQueryNormalizationDebug({ ...snapshot, context });
    };
 }

--- a/src/utils/querySignature.test.ts
+++ b/src/utils/querySignature.test.ts
@@ -1,0 +1,57 @@
+import { strict as assert } from 'assert';
+import { buildQuerySignature } from './querySignature';
+
+async function run() {
+   // Test stable output for same params in different order
+   const query1 = { a: 1, b: 2, c: 3 };
+   const query2 = { c: 3, b: 2, a: 1 };
+   const sig1 = buildQuerySignature(query1);
+   const sig2 = buildQuerySignature(query2);
+   assert.equal(sig1, sig2, 'Signatures should be identical for same params in different order');
+
+   // Test sensitive fields are excluded
+   const queryWithSensitive = {
+      limit: 10,
+      search: 'test',
+      token: 'secret123',
+      password: 'pass',
+      apiKey: 'key123'
+   };
+   const querySafe = {
+      limit: 10,
+      search: 'test'
+   };
+   const sigSensitive = buildQuerySignature(queryWithSensitive);
+   const sigSafe = buildQuerySignature(querySafe);
+   assert.equal(sigSensitive, sigSafe, 'Sensitive fields should be excluded from signature');
+
+   // Test empty query returns consistent signature
+   const emptySig1 = buildQuerySignature({});
+   const emptySig2 = buildQuerySignature({});
+   assert.equal(emptySig1, emptySig2, 'Empty query should return consistent signature');
+   assert.ok(typeof emptySig1 === 'string' && emptySig1.length === 64, 'Should return 64-character hex string');
+
+   // Test different queries produce different signatures
+   const queryA = { limit: 5 };
+   const queryB = { limit: 10 };
+   const sigA = buildQuerySignature(queryA);
+   const sigB = buildQuerySignature(queryB);
+   assert.notEqual(sigA, sigB, 'Different queries should produce different signatures');
+
+   // Test complex values are handled
+   const complexQuery = {
+      arr: [1, 2, 3],
+      obj: { nested: 'value' },
+      bool: true,
+      num: 42
+   };
+   const complexSig = buildQuerySignature(complexQuery);
+   assert.ok(typeof complexSig === 'string' && complexSig.length === 64, 'Complex values should be handled');
+
+   console.log('querySignature.utils tests passed');
+}
+
+run().catch((err) => {
+   console.error(err);
+   process.exit(1);
+});

--- a/src/utils/querySignature.ts
+++ b/src/utils/querySignature.ts
@@ -1,0 +1,62 @@
+import { createHash } from 'crypto';
+
+/**
+ * Sensitive field patterns that should be excluded from query signatures.
+ * These patterns match field names that might contain PII, tokens, or other sensitive data.
+ */
+const SENSITIVE_FIELD_PATTERNS = [
+   'password',
+   'token',
+   'secret',
+   'key',
+   'auth',
+   'credential',
+   'email',
+   'phone',
+   'ssn',
+   'credit',
+   'card',
+] as const;
+
+/**
+ * Check if a field name matches any sensitive pattern.
+ * Case-insensitive matching to catch variations like 'Password', 'AUTH_TOKEN', etc.
+ */
+function isSensitiveField(fieldName: string): boolean {
+   const lowerField = fieldName.toLowerCase();
+   return SENSITIVE_FIELD_PATTERNS.some(pattern => lowerField.includes(pattern));
+}
+
+/**
+ * Builds a deterministic query signature for cache diagnostics.
+ *
+ * This function creates a stable hash of query parameters that can be used
+ * to identify equivalent requests for caching purposes. Sensitive fields
+ * are excluded to prevent leaking credentials in logs.
+ *
+ * @param query - The query parameters object
+ * @returns A SHA-256 hash string representing the normalized query
+ *
+ * @example
+ * ```ts
+ * const signature = buildQuerySignature({
+ *   limit: 20,
+ *   search: 'example',
+ *   token: 'secret123' // This will be excluded
+ * });
+ * // Returns: 'a1b2c3d4...' (deterministic hash)
+ * ```
+ */
+export function buildQuerySignature(query: Record<string, unknown>): string {
+   // Filter out sensitive fields
+   const safeEntries = Object.entries(query).filter(([key]) => !isSensitiveField(key));
+
+   // Sort keys alphabetically for deterministic ordering
+   safeEntries.sort(([a], [b]) => a.localeCompare(b));
+
+   // Create a normalized string representation
+   const normalized = safeEntries.map(([key, value]) => `${key}:${JSON.stringify(value)}`).join('|');
+
+   // Generate SHA-256 hash
+   return createHash('sha256').update(normalized).digest('hex');
+}

--- a/src/utils/test/query-normalization-debug.utils.test.ts
+++ b/src/utils/test/query-normalization-debug.utils.test.ts
@@ -334,6 +334,38 @@ function run() {
       restoreLogger();
    }
 
+   // Test 11: Query signature is included for object queries
+   {
+      mockLogger(true);
+      emitQueryNormalizationDebug({
+         raw: { limit: 10, offset: 0, search: 'test' },
+         normalized: { limit: 10, offset: 0, search: 'test' },
+         valid: true,
+         context: 'test-query',
+      });
+
+      const snapshot = debugCalls[0].queryNormalization;
+      assertOk(snapshot.querySignature, 'Should include querySignature');
+      assertEqual(typeof snapshot.querySignature, 'string', 'Signature should be a string');
+      assertEqual(snapshot.querySignature.length, 64, 'Signature should be 64 characters (SHA-256 hex)');
+      restoreLogger();
+   }
+
+   // Test 12: Query signature is not included for non-object queries
+   {
+      mockLogger(true);
+      emitQueryNormalizationDebug({
+         raw: 'not an object',
+         normalized: null,
+         valid: false,
+         errors: [{ field: 'query', message: 'Invalid' }],
+      });
+
+      const snapshot = debugCalls[0].queryNormalization;
+      assertEqual(snapshot.querySignature, undefined, 'Should not include signature for non-object raw query');
+      restoreLogger();
+   }
+
    console.log('✓ All query-normalization-debug.utils tests passed');
 }
 


### PR DESCRIPTION
Closes #223 



Adds a stable query signature helper for use in cache diagnostics.

## Changes
- Created `src/utils/querySignature.ts` — produces deterministic SHA256 
  signatures from normalized query fields using Node built-in crypto
- Integrated `querySignature` field into `QueryNormalizationSnapshot` interface
- Updated `emitQueryNormalizationDebug` to compute and include signatures 
  for object queries in debug logs
- Updated related tests to verify signature inclusion

## Notes
- Sensitive fields are excluded from signature generation
- Keys are sorted alphabetically for stability (same params = same signature)
- No new dependencies — uses Node built-in crypto only
- Scoped change only, no unrelated file churn

## Testing
- Tests stable output for same params in different order
- Tests sensitive field exclusion
- Tests empty query returns consistent signature
- Tests complex values (arrays, objects) are handled