### PR TITLE
feat: null-safe creator list envelope consistency check

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
   transform: {
     ...tsJestTransformCfg,
   },
+  setupFiles: ["./jest.setup.ts"],
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,16 @@
+// Test environment stub — sets all required env vars before any module loads.
+// Values are non-functional placeholders sufficient for schema validation.
+
+process.env.MODE = 'test';
+process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+process.env.GMAIL_USER = 'test@example.com';
+process.env.GMAIL_APP_PASSWORD = 'test-password';
+process.env.GOOGLE_CLIENT_ID = 'test-google-client-id';
+process.env.GOOGLE_CLIENT_SECRET = 'test-google-client-secret';
+process.env.BACKEND_URL = 'http://localhost:3000';
+process.env.FRONTEND_URL = 'http://localhost:5173';
+process.env.CLOUDINARY_CLOUD_NAME = 'test-cloud';
+process.env.CLOUDINARY_API_KEY = 'test-api-key';
+process.env.CLOUDINARY_API_SECRET = 'test-api-secret';
+process.env.PAYSTACK_SECRET_KEY = 'test-paystack-secret';
+process.env.APP_SECRET = 'accesslayer_test_secret_key_32_bytes_long_xxxx';

--- a/src/modules/creators/creator-feed-empty-filters.integration.test.ts
+++ b/src/modules/creators/creator-feed-empty-filters.integration.test.ts
@@ -18,6 +18,7 @@ function makeRes(): any {
    res.status = jest.fn().mockReturnValue(res);
    res.json = jest.fn().mockReturnValue(res);
    res.setHeader = jest.fn().mockReturnValue(res);
+   res.set = jest.fn().mockReturnValue(res);
    return res;
 }
 
@@ -127,12 +128,12 @@ describe('GET /api/v1/creators — empty feed with filter combinations', () => {
       const res = makeRes();
       await httpListCreators(req, res, makeNext());
 
-      expect(creatorsUtils.fetchCreatorList).toHaveBeenCalledWith(
-         expect.objectContaining({
-            verified: undefined,
-            search: undefined,
-         })
-      );
+      // Optional filter keys are absent from the Zod output when not supplied;
+      // asserting absence is more accurate than asserting `undefined` equality.
+      const callArgs = (creatorsUtils.fetchCreatorList as jest.Mock).mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty('verified', true);
+      expect(callArgs).not.toHaveProperty('verified', false);
+      expect(callArgs).not.toHaveProperty('search');
 
       const body = res.json.mock.calls[0][0];
       expect(body.data.items).toHaveLength(0);
@@ -389,6 +390,55 @@ describe('GET /api/v1/creators — empty feed with filter combinations', () => {
          // Reset mocks for next iteration
          jest.clearAllMocks();
          jest.spyOn(creatorsUtils, 'fetchCreatorList').mockResolvedValue([[], 0]);
+      }
+   });
+
+   // ── Null Items Normalization (issue #281) ──────────────────────────────────
+
+   it('coerces null items from fetchCreatorList to an empty array', async () => {
+      jest.spyOn(creatorsUtils, 'fetchCreatorList').mockResolvedValue([null as unknown as any[], 0]);
+      const req = makeReq();
+      const res = makeRes();
+      await httpListCreators(req, res, makeNext());
+
+      const body = res.json.mock.calls[0][0];
+      expect(body.success).toBe(true);
+      expect(Array.isArray(body.data.items)).toBe(true);
+      expect(body.data.items).toHaveLength(0);
+   });
+
+   it('coerces undefined items from fetchCreatorList to an empty array', async () => {
+      jest.spyOn(creatorsUtils, 'fetchCreatorList').mockResolvedValue([undefined as unknown as any[], 0]);
+      const req = makeReq();
+      const res = makeRes();
+      await httpListCreators(req, res, makeNext());
+
+      const body = res.json.mock.calls[0][0];
+      expect(body.success).toBe(true);
+      expect(Array.isArray(body.data.items)).toBe(true);
+      expect(body.data.items).toHaveLength(0);
+   });
+
+   it('items is always an array regardless of filter combination when data layer returns null', async () => {
+      jest.spyOn(creatorsUtils, 'fetchCreatorList').mockResolvedValue([null as unknown as any[], 0]);
+      const filterCombinations: Array<Record<string, string>> = [
+         { verified: 'true' },
+         { search: 'artist' },
+         { verified: 'false', search: 'test' },
+         { limit: '5', offset: '10', verified: 'true' },
+      ];
+
+      for (const query of filterCombinations) {
+         const req = makeReq(query);
+         const res = makeRes();
+         await httpListCreators(req, res, makeNext());
+
+         const body = res.json.mock.calls[0][0];
+         expect(Array.isArray(body.data.items)).toBe(true);
+         expect(body.data.items).toHaveLength(0);
+
+         jest.clearAllMocks();
+         jest.spyOn(creatorsUtils, 'fetchCreatorList').mockResolvedValue([null as unknown as any[], 0]);
       }
    });
 

--- a/src/modules/creators/creators.serializers.ts
+++ b/src/modules/creators/creators.serializers.ts
@@ -49,15 +49,30 @@ export function serializeCreatorSummary(
 }
 
 /**
- * Serializes multiple creator profiles for list responses.
+ * Normalizes a potentially-null or undefined profile list to a safe empty array.
+ * Guards serialization against edge cases where the data layer returns null.
  *
- * @param profiles - Array of full creator profiles
- * @returns Array of creator summaries
+ * @param profiles - Raw profiles array that may be null or undefined
+ * @returns A guaranteed non-null array
+ */
+export function normalizeCreatorListItems(
+   profiles: CreatorProfile[] | null | undefined
+): CreatorProfile[] {
+   return profiles ?? [];
+}
+
+/**
+ * Serializes multiple creator profiles for list responses.
+ * Accepts null/undefined and coerces it to an empty array before mapping,
+ * so the items field in the response envelope is always an array.
+ *
+ * @param profiles - Array of full creator profiles (null/undefined treated as empty)
+ * @returns Array of creator list items
  */
 export function serializeCreatorList(
-   profiles: CreatorProfile[]
+   profiles: CreatorProfile[] | null | undefined
 ): CreatorListItem[] {
-   return profiles.map(mapCreatorListItem);
+   return normalizeCreatorListItems(profiles).map(mapCreatorListItem);
 }
 
 /**

--- a/src/modules/creators/public-creator-list-envelope.utils.ts
+++ b/src/modules/creators/public-creator-list-envelope.utils.ts
@@ -11,10 +11,11 @@ export type PublicCreatorListEnvelope<TItem, TMeta> = {
 
 /**
  * Wraps list results and metadata in a single predictable object for public list routes.
+ * Coerces null/undefined items to an empty array so the envelope is always well-formed.
  */
 export function wrapPublicCreatorListResponse<TItem, TMeta>(
-   items: TItem[],
+   items: TItem[] | null | undefined,
    meta: TMeta
 ): PublicCreatorListEnvelope<TItem, TMeta> {
-   return { items, meta };
+   return { items: items ?? [], meta };
 }


### PR DESCRIPTION
## What changed

- Added `normalizeCreatorListItems()` helper in `creators.serializers.ts` that coerces `null | undefined` profiles to `[]` before mapping, so the `items` field is always an array.
- Updated `serializeCreatorList()` signature to accept `CreatorProfile[] | null | undefined`.
- Updated `wrapPublicCreatorListResponse()` in `public-creator-list-envelope.utils.ts` to coerce `null | undefined` items to `[]` at the envelope level (defence-in-depth).
- Added `jest.setup.ts` + wired `setupFiles` in `jest.config.js` so Jest can load modules that transitively import `src/config.ts` without requiring real env vars.
- Extended `creator-feed-empty-filters.integration.test.ts` with 3 tests asserting `items` is always an array when the data layer returns `null` or `undefined`.
- Fixed a pre-existing assertion bug in the same file: `objectContaining({ verified: undefined })` incorrectly assumed Zod emits optional absent keys with `undefined`; corrected to check key absence instead.
- Fixed missing `res.set` mock in `makeRes()` which caused `attachTimestampHeader` to throw, silently swallowing all responses.

## Why

Creator list endpoints may return `null` instead of an empty array in edge cases, breaking any client-side iteration that calls `.map()` or `.forEach()` on `items` without a null guard.

## How to test

```bash
pnpm exec jest --testPathPatterns "creator-feed-empty-filters"
# → Tests: 29 passed
```

Closes #281