### PR TITLE
fix: sync env example with schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,38 +1,49 @@
 PORT=3000
 MODE=development
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/accesslayer
 BACKEND_URL=http://localhost:3000
 FRONTEND_URL=http://localhost:5173
 
-# Docker Postgres defaults
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/accesslayer
-DB_QUERY_TIMEOUT_MS=5000
-APP_SECRET=your_32_character_long_secret_string_here
-
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
-GOOGLE_REDIRECT_URI=http://localhost:3000/api/v1/admin/auth/google/callback
-
+# Required third-party credentials
 GMAIL_USER=
 GMAIL_APP_PASSWORD=
-
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
 CLOUDINARY_CLOUD_NAME=
 CLOUDINARY_API_KEY=
 CLOUDINARY_API_SECRET=
-
 PAYSTACK_SECRET_KEY=
+
+# Optional third-party credentials
 PAYSTACK_PUBLIC_KEY=
 
-# API Configuration
+# Runtime defaults
+DB_QUERY_TIMEOUT_MS=5000
+APP_SECRET=your_32_character_long_secret_string_here
 API_VERSION=1.0.0
+ENABLE_RESPONSE_TIMING=true
 ENABLE_API_VERSION_HEADER=true
 ENABLE_SCHEMA_VERSION_HEADER=true
-ENABLE_RESPONSE_TIMING=true
 ENABLE_REQUEST_LOGGING=true
 
-# Indexer Configuration
+# Creator and indexer tuning
+INDEXER_JITTER_FACTOR=0.1
 BACKGROUND_JOB_LOCK_TTL_MS=300000
-# Indexer cursor stale-age warning threshold in milliseconds (default: 300000 = 5 minutes)
+CREATOR_LIST_SLOW_QUERY_THRESHOLD_MS=500
 INDEXER_CURSOR_STALE_AGE_WARNING_MS=300000
-# Time in milliseconds before the indexer is considered stale
 INDEXER_HEARTBEAT_STALE_THRESHOLD_MS=300000
+ENABLE_INDEXER_DEDUPE=true
+ENABLE_INDEXER_DLQ=true
+ENABLE_INDEXER_CURSOR_STALENESS_WARNING=true
 
+# Stellar network
+STELLAR_NETWORK=testnet
+STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+STELLAR_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# Ownership snapshot cleanup job
+OWNERSHIP_SNAPSHOT_TABLE_NAME=creator_ownership_snapshots
+OWNERSHIP_SNAPSHOT_CLEANUP_DRY_RUN=true
+OWNERSHIP_SNAPSHOT_RETENTION_DAYS=30
+OWNERSHIP_SNAPSHOT_CLEANUP_ENABLED=false
+OWNERSHIP_SNAPSHOT_CLEANUP_INTERVAL_MINUTES=60

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,6 +118,7 @@ These values have defaults and can be overridden:
 | -------------------------------------- | ------- | ------------- | ----------------------------- |
 | `PORT`                                 | number  | `3000`        | Server port                   |
 | `MODE`                                 | enum    | `development` | Environment mode              |
+| `DB_QUERY_TIMEOUT_MS`                  | number  | `5000`        | Prisma query timeout in ms    |
 | `APP_SECRET`                           | string  | (dev key)     | Secret for signing/encryption |
 | `API_VERSION`                          | string  | `1.0.0`       | API version string            |
 | `ENABLE_RESPONSE_TIMING`               | boolean | `true`        | Enable timing headers         |
@@ -128,6 +129,18 @@ These values have defaults and can be overridden:
 | `BACKGROUND_JOB_LOCK_TTL_MS`           | number  | `300000`      | Job lock TTL (5 min)          |
 | `CREATOR_LIST_SLOW_QUERY_THRESHOLD_MS` | number  | `500`         | Slow query threshold          |
 | `INDEXER_CURSOR_STALE_AGE_WARNING_MS`  | number  | `300000`      | Stale cursor warning (5 min)  |
+| `INDEXER_HEARTBEAT_STALE_THRESHOLD_MS` | number  | `300000`      | Heartbeat stale threshold     |
+| `ENABLE_INDEXER_DEDUPE`                | boolean | `true`        | Enable dedupe guard           |
+| `ENABLE_INDEXER_DLQ`                   | boolean | `true`        | Enable indexer dead-lettering |
+| `ENABLE_INDEXER_CURSOR_STALENESS_WARNING` | boolean | `true`      | Warn on stale cursors         |
+| `STELLAR_NETWORK`                      | enum    | `testnet`     | Stellar network selection     |
+| `STELLAR_HORIZON_URL`                  | URL     | testnet URL   | Horizon endpoint              |
+| `STELLAR_SOROBAN_RPC_URL`              | URL     | testnet URL   | Soroban RPC endpoint          |
+| `OWNERSHIP_SNAPSHOT_TABLE_NAME`        | string  | `creator_ownership_snapshots` | Snapshot table name |
+| `OWNERSHIP_SNAPSHOT_CLEANUP_DRY_RUN`   | boolean | `true`        | Log deletes without executing |
+| `OWNERSHIP_SNAPSHOT_RETENTION_DAYS`    | number  | `30`          | Retention window in days      |
+| `OWNERSHIP_SNAPSHOT_CLEANUP_ENABLED`   | boolean | `false`       | Enable cleanup scheduler      |
+| `OWNERSHIP_SNAPSHOT_CLEANUP_INTERVAL_MINUTES` | number | `60`    | Cleanup scheduler interval    |
 | `PAYSTACK_PUBLIC_KEY`                  | string  | (optional)    | Paystack public key           |
 
 **Startup Behavior:** Uses default if not provided in environment.


### PR DESCRIPTION
Closes #320 
Closes #316 
Closes #319 

## Summary
- Synced `.env.example` with the actual runtime config schema.
- Removed the unused `GOOGLE_REDIRECT_URI` example.
- Added the missing config entries for runtime defaults, indexer settings, Stellar network settings, and ownership snapshot cleanup.
- Updated `docs/configuration.md` so the documented env contract matches the example file and schema.


## Testing
- `git diff --check`
- Reviewed the final diff for `.env.example` and `docs/configuration.md`
