### PR TITLE
Log unexpected null creator field

### DIFF
--- a/src/modules/creators/creator-list-item.mapper.test.ts
+++ b/src/modules/creators/creator-list-item.mapper.test.ts
@@ -1,19 +1,51 @@
-import { strict as assert } from 'assert';
 import { mapCreatorListItem } from './creator-list-item.mapper';
+import { requestContextStorage } from '../../utils/als.utils';
+import { logger } from '../../utils/logger.utils';
 
-function run() {
-   const input = { id: '1', displayName: 'John', avatarUrl: null } as any;
+jest.mock('../../utils/logger.utils', () => ({
+   logger: { warn: jest.fn() },
+}));
 
-   const result = mapCreatorListItem(input);
+const warnMock = logger.warn as jest.Mock;
 
-   assert.deepEqual(result, {
-      id: '1',
-      name: 'John',
-      avatar: null,
-      followers: 0,
+beforeEach(() => {
+   warnMock.mockClear();
+});
+
+describe('mapCreatorListItem()', () => {
+   it('maps the public creator list item shape', () => {
+      const input = { id: '1', displayName: 'John', avatarUrl: null } as any;
+
+      const result = mapCreatorListItem(input);
+
+      expect(result).toEqual({
+         id: '1',
+         name: 'John',
+         avatar: null,
+         followers: 0,
+      });
+      expect(warnMock).not.toHaveBeenCalled();
    });
 
-   console.log('creator-list-item.mapper test passed');
-}
+   it('warns when a schema-required creator field is unexpectedly null', () => {
+      const input = { id: 'creator-1', displayName: null, avatarUrl: null } as any;
 
-run();
+      const result = requestContextStorage.run(
+         { path: '/api/v1/creators', method: 'GET', requestId: 'req-333' },
+         () => mapCreatorListItem(input)
+      );
+
+      expect(result).toEqual({
+         id: 'creator-1',
+         name: null,
+         avatar: null,
+         followers: 0,
+      });
+      expect(warnMock).toHaveBeenCalledWith({
+         msg: 'Unexpected null creator field in database result',
+         fieldName: 'displayName',
+         creatorId: 'creator-1',
+         requestId: 'req-333',
+      });
+   });
+});

--- a/src/modules/creators/creator-list-item.mapper.ts
+++ b/src/modules/creators/creator-list-item.mapper.ts
@@ -1,4 +1,6 @@
 import { CreatorProfile } from '../../types/profile.types';
+import { requestContextStorage } from '../../utils/als.utils';
+import { logger } from '../../utils/logger.utils';
 import { safeRead } from '../../utils/safe-nested-read.utils';
 
 /**
@@ -12,6 +14,24 @@ export type CreatorListItem = {
    followers: number;
 };
 
+function warnIfUnexpectedNullCreatorField(
+   creator: CreatorProfile,
+   fieldName: 'displayName'
+): void {
+   const rawCreator = creator as CreatorProfile & Record<string, unknown>;
+
+   if (rawCreator[fieldName] !== null) {
+      return;
+   }
+
+   logger.warn({
+      msg: 'Unexpected null creator field in database result',
+      fieldName,
+      creatorId: creator.id,
+      requestId: requestContextStorage.getStore()?.requestId ?? null,
+   });
+}
+
 /**
  * Pure, dumb mapper from a full `CreatorProfile` to a `CreatorListItem`.
  * No filtering, no business logic — deterministic and predictable.
@@ -19,6 +39,8 @@ export type CreatorListItem = {
 export const mapCreatorListItem = (
    creator: CreatorProfile
 ): CreatorListItem => {
+   warnIfUnexpectedNullCreatorField(creator, 'displayName');
+
    return {
       id: creator.id,
       name: safeRead(creator, 'displayName', null),


### PR DESCRIPTION
Summary
- Added a warn-level structured log in the creator list result mapper when `displayName`, a non-nullable `CreatorProfile` schema field, is unexpectedly returned as `null` from the database. The mapper still returns the same public response shape as before, so the null case continues to serialize as `name: null` for clients while giving maintainers visibility into the data integrity problem.

Issue
- Closes #333

Changes
- Added null detection for the schema-required `displayName` field during creator list item mapping.
- Included `fieldName`, `creatorId`, and `requestId` in the warning payload.
- Read the request ID from the existing async request context so the log can be correlated with the request that produced the mapped result.
- Converted the mapper coverage to Jest assertions and added a regression test proving the null response behavior remains unchanged while the warning is emitted.

Validation
- `pnpm.cmd exec jest src/modules/creators/creator-list-item.mapper.test.ts --runInBand` passed.
- `pnpm.cmd lint` passed.
- `pnpm.cmd build` was run but did not complete successfully because Prisma Client was not generated in this Windows environment after pnpm blocked dependency build scripts. `pnpm.cmd exec prisma generate` and `pnpm.cmd exec prisma --version` both timed out before producing output, so the build failure appears environment/tooling-related rather than caused by this mapper change.

Notes
- The public client response for the unexpected null case is intentionally unchanged.
- `pnpm-lock.yaml` was not modified.