### PR TITLE
Standardize creator timestamp formatting

### DIFF
--- a/src/constants/creator-list-projection.constants.ts
+++ b/src/constants/creator-list-projection.constants.ts
@@ -17,6 +17,8 @@
  * - displayName: Creator's display name
  * - avatarUrl: URL to creator's avatar image
  * - isVerified: Verification status badge
+ * - createdAt: Creator registration timestamp
+ * - updatedAt: Creator profile update timestamp
  */
 export const CREATOR_LIST_DEFAULT_SELECT = {
   id: true,
@@ -24,6 +26,8 @@ export const CREATOR_LIST_DEFAULT_SELECT = {
   displayName: true,
   avatarUrl: true,
   isVerified: true,
+  createdAt: true,
+  updatedAt: true,
 } as const;
 
 export type CreatorListSelectKeys = keyof typeof CREATOR_LIST_DEFAULT_SELECT;

--- a/src/modules/creator/creator-detail-cache-headers.integration.test.ts
+++ b/src/modules/creator/creator-detail-cache-headers.integration.test.ts
@@ -36,6 +36,8 @@ const FIXTURE_PROFILE = {
    displayName: 'Test Creator',
    bio: 'A bio',
    avatarUrl: 'https://example.com/avatar.png',
+   createdAt: '2024-01-01T00:00:00.000Z',
+   updatedAt: '2024-01-02T00:00:00.000Z',
    perks: [],
    links: [],
    metadata: { source: 'database' as const, isProfileComplete: true },

--- a/src/modules/creator/creator-profile.schemas.ts
+++ b/src/modules/creator/creator-profile.schemas.ts
@@ -43,6 +43,8 @@ export const CreatorProfileReadResponseSchema = z.object({
    displayName: z.string().nullable(),
    bio: z.string().nullable(),
    avatarUrl: z.string().url().nullable(),
+   createdAt: z.string().datetime().nullable(),
+   updatedAt: z.string().datetime().nullable(),
    perks: z.array(CreatorPerkSchema).optional(),
    links: z.array(z.object({ label: z.string(), url: z.string().url() })),
    metadata: z.object({

--- a/src/modules/creator/creator-profile.service.test.ts
+++ b/src/modules/creator/creator-profile.service.test.ts
@@ -13,6 +13,8 @@ describe('getCreatorProfile', () => {
          displayName: null,
          bio: null,
          avatarUrl: null,
+         createdAt: null,
+         updatedAt: null,
          links: [],
          metadata: {
             source: 'placeholder',

--- a/src/modules/creator/creator-profile.service.ts
+++ b/src/modules/creator/creator-profile.service.ts
@@ -5,6 +5,7 @@ import {
    UpsertCreatorProfileBody,
 } from './creator-profile.schemas';
 import { CREATOR_DETAIL_DEFAULT_SELECT } from '../../constants/creator-detail-include.constants';
+import { formatIsoTimestamp } from '../../utils/iso-timestamp.utils';
 import { normalizeSocialLinkUrl } from './creator-social-link-url.utils';
 
 function normalizeProfileLinks(
@@ -59,6 +60,8 @@ export async function getCreatorProfile(
          displayName: null,
          bio: null,
          avatarUrl: null,
+         createdAt: null,
+         updatedAt: null,
          perks: [],
          links: [],
          metadata: {
@@ -73,6 +76,8 @@ export async function getCreatorProfile(
       displayName: profile.displayName,
       bio: profile.bio,
       avatarUrl: profile.avatarUrl,
+      createdAt: formatIsoTimestamp(profile.createdAt),
+      updatedAt: formatIsoTimestamp(profile.updatedAt),
       perks: (profile.perks as any) || [],
       links: [], // Links are not yet in the Prisma model, keeping as part of contract
       metadata: {

--- a/src/modules/creators/creator-list-item.mapper.test.ts
+++ b/src/modules/creators/creator-list-item.mapper.test.ts
@@ -14,7 +14,13 @@ beforeEach(() => {
 
 describe('mapCreatorListItem()', () => {
    it('maps the public creator list item shape', () => {
-      const input = { id: '1', displayName: 'John', avatarUrl: null } as any;
+      const input = {
+         id: '1',
+         displayName: 'John',
+         avatarUrl: null,
+         createdAt: new Date('2024-01-02T03:04:05.678Z'),
+         updatedAt: new Date('2024-01-03T03:04:05.678Z'),
+      } as any;
 
       const result = mapCreatorListItem(input);
 
@@ -23,12 +29,20 @@ describe('mapCreatorListItem()', () => {
          name: 'John',
          avatar: null,
          followers: 0,
+         createdAt: '2024-01-02T03:04:05.678Z',
+         updatedAt: '2024-01-03T03:04:05.678Z',
       });
       expect(warnMock).not.toHaveBeenCalled();
    });
 
    it('warns when a schema-required creator field is unexpectedly null', () => {
-      const input = { id: 'creator-1', displayName: null, avatarUrl: null } as any;
+      const input = {
+         id: 'creator-1',
+         displayName: null,
+         avatarUrl: null,
+         createdAt: new Date('2024-01-02T03:04:05.678Z'),
+         updatedAt: new Date('2024-01-03T03:04:05.678Z'),
+      } as any;
 
       const result = requestContextStorage.run(
          { path: '/api/v1/creators', method: 'GET', requestId: 'req-333' },
@@ -40,6 +54,8 @@ describe('mapCreatorListItem()', () => {
          name: null,
          avatar: null,
          followers: 0,
+         createdAt: '2024-01-02T03:04:05.678Z',
+         updatedAt: '2024-01-03T03:04:05.678Z',
       });
       expect(warnMock).toHaveBeenCalledWith({
          msg: 'Unexpected null creator field in database result',

--- a/src/modules/creators/creator-list-item.mapper.ts
+++ b/src/modules/creators/creator-list-item.mapper.ts
@@ -1,5 +1,6 @@
 import { CreatorProfile } from '../../types/profile.types';
 import { requestContextStorage } from '../../utils/als.utils';
+import { formatIsoTimestamp } from '../../utils/iso-timestamp.utils';
 import { logger } from '../../utils/logger.utils';
 import { safeRead } from '../../utils/safe-nested-read.utils';
 
@@ -12,6 +13,8 @@ export type CreatorListItem = {
    name: string | null;
    avatar: string | null;
    followers: number;
+   createdAt: string;
+   updatedAt: string;
 };
 
 function warnIfUnexpectedNullCreatorField(
@@ -46,5 +49,7 @@ export const mapCreatorListItem = (
       name: safeRead(creator, 'displayName', null),
       avatar: safeRead(creator, 'avatarUrl', null),
       followers: 0,
+      createdAt: formatIsoTimestamp(creator.createdAt),
+      updatedAt: formatIsoTimestamp(creator.updatedAt),
    };
 };

--- a/src/modules/creators/creator-route-content-type.integration.test.ts
+++ b/src/modules/creators/creator-route-content-type.integration.test.ts
@@ -56,6 +56,8 @@ const FIXTURE_PROFILE = {
    displayName: 'Test Creator',
    bio: 'Test bio',
    avatarUrl: 'https://example.com/avatar.png',
+   createdAt: '2024-01-01T00:00:00.000Z',
+   updatedAt: '2024-01-02T00:00:00.000Z',
    perks: [],
    links: [],
    metadata: { source: 'database' as const, isProfileComplete: true },

--- a/src/modules/creators/creators.serializers.ts
+++ b/src/modules/creators/creators.serializers.ts
@@ -17,7 +17,7 @@
  *
  * | Field | When empty / unknown |
  * |-------|----------------------|
- * | `id`, `followers` | Always present (`followers` is a number, currently `0`). |
+ * | `id`, `followers`, `createdAt`, `updatedAt` | Always present (`followers` is a number, currently `0`; timestamps use ISO 8601 UTC strings). |
  * | `name`, `avatar` | **Always present**; use JSON **`null`** when display name or avatar URL is missing (`?? null` in the mapper). |
  *
  * List envelope (`items`, `meta`) always includes both keys. Offset `meta` always
@@ -39,6 +39,7 @@
  * | Field | When empty / unknown |
  * |-------|----------------------|
  * | `creatorId`, `metadata` | Always present. |
+ * | `createdAt`, `updatedAt` | Always present; ISO 8601 UTC strings for database records, JSON **`null`** for placeholder responses. |
  * | `displayName`, `bio`, `avatarUrl` | **Always present**; JSON **`null`** when unset (Zod `.nullable()`; placeholder fallback uses explicit `null`). |
  * | `links` | **Always present** as an array; use **`[]`** when there are no links (never `null`, never omitted). |
  * | `perks` | **Always present** as an array in current handlers (`[]` when none). The read schema marks `perks` optional, but the service always includes the key. |

--- a/src/utils/iso-timestamp.utils.test.ts
+++ b/src/utils/iso-timestamp.utils.test.ts
@@ -1,0 +1,17 @@
+import { formatIsoTimestamp } from './iso-timestamp.utils';
+
+describe('formatIsoTimestamp()', () => {
+   it('formats supported timestamp inputs with one ISO 8601 UTC representation', () => {
+      const expected = '2024-01-02T03:04:05.678Z';
+
+      expect(formatIsoTimestamp(new Date(expected))).toBe(expected);
+      expect(formatIsoTimestamp('2024-01-02T04:04:05.678+01:00')).toBe(
+         expected
+      );
+      expect(formatIsoTimestamp(Date.parse(expected))).toBe(expected);
+   });
+
+   it('rejects invalid timestamp values', () => {
+      expect(() => formatIsoTimestamp('not-a-date')).toThrow(RangeError);
+   });
+});

--- a/src/utils/iso-timestamp.utils.ts
+++ b/src/utils/iso-timestamp.utils.ts
@@ -1,0 +1,14 @@
+export type TimestampInput = Date | string | number;
+
+/**
+ * Formats API response timestamps as UTC ISO 8601 strings with milliseconds.
+ */
+export function formatIsoTimestamp(value: TimestampInput): string {
+   const date = value instanceof Date ? value : new Date(value);
+
+   if (Number.isNaN(date.getTime())) {
+      throw new RangeError('Invalid timestamp value');
+   }
+
+   return date.toISOString();
+}


### PR DESCRIPTION
Summary
- Added a shared `formatIsoTimestamp` helper that normalizes timestamp inputs to a single UTC ISO 8601 representation with milliseconds. Creator list items and creator detail responses now use the helper for `createdAt` and `updatedAt`, so clients receive consistently formatted timestamp strings across those response paths.

Issue
- Closes #345

Changes
- Added `src/utils/iso-timestamp.utils.ts` with validation for invalid timestamp values.
- Added unit coverage confirming Date, string-with-offset, and numeric timestamp inputs all produce the same ISO 8601 UTC output.
- Included `createdAt` and `updatedAt` in the creator list projection and mapped them through the new helper in `mapCreatorListItem`.
- Added `createdAt` and `updatedAt` to creator detail response schema and formatted database values through the helper.
- Kept placeholder creator detail responses explicit by returning `createdAt: null` and `updatedAt: null` when no database row exists.
- Updated nearby response-shape tests and serializer documentation for the new timestamp fields.

Validation
- `pnpm.cmd exec jest src/utils/iso-timestamp.utils.test.ts src/modules/creators/creator-list-item.mapper.test.ts --runInBand` passed.
- `pnpm.cmd lint` passed.
- `pnpm.cmd build` was run and now only fails on generated Prisma Client exports missing from `@prisma/client` (`Prisma`, `PrismaClient`, `StellarWallet`, `User`). This matches the local environment issue where Prisma Client generation is unavailable/stale, not the timestamp changes.

Notes
- The supplied `InsightArena` fork URL does not match `accesslayerorg/accesslayer-server`; this work used the existing verified local checkout with origin `utahkanz-ops/accesslayer-server` and upstream `accesslayerorg/accesslayer-server`.
- `pnpm-lock.yaml` was not modified.