### PR TITLE
Added Structured logs for creator list query

### DIFF
--- a/src/modules/creators/creator-list-item.mapper.test.ts
+++ b/src/modules/creators/creator-list-item.mapper.test.ts
@@ -3,13 +3,15 @@ import { requestContextStorage } from '../../utils/als.utils';
 import { logger } from '../../utils/logger.utils';
 
 jest.mock('../../utils/logger.utils', () => ({
-   logger: { warn: jest.fn() },
+   logger: { warn: jest.fn(), error: jest.fn() },
 }));
 
 const warnMock = logger.warn as jest.Mock;
+const errorMock = logger.error as jest.Mock;
 
 beforeEach(() => {
    warnMock.mockClear();
+   errorMock.mockClear();
 });
 
 describe('mapCreatorListItem()', () => {
@@ -63,5 +65,83 @@ describe('mapCreatorListItem()', () => {
          creatorId: 'creator-1',
          requestId: 'req-333',
       });
+   });
+
+   it('logs an error when a string field receives an unexpected type', () => {
+      const input = {
+         id: 'creator-2',
+         handle: 'test-handle',
+         displayName: 12345, // number instead of string
+         avatarUrl: null,
+         isVerified: false,
+         createdAt: new Date('2024-01-02T03:04:05.678Z'),
+         updatedAt: new Date('2024-01-03T03:04:05.678Z'),
+      } as any;
+
+      const result = requestContextStorage.run(
+         { path: '/api/v1/creators', method: 'GET', requestId: 'req-type-1' },
+         () => mapCreatorListItem(input)
+      );
+
+      expect(result).toEqual({
+         id: 'creator-2',
+         name: 12345,
+         avatar: null,
+         followers: 0,
+         createdAt: '2024-01-02T03:04:05.678Z',
+         updatedAt: '2024-01-03T03:04:05.678Z',
+      });
+      expect(errorMock).toHaveBeenCalledWith({
+         msg: 'Creator list field type mismatch',
+         fieldName: 'displayName',
+         expectedType: 'string',
+         receivedType: 'number',
+         creatorId: 'creator-2',
+         requestId: 'req-type-1',
+      });
+   });
+
+   it('logs an error when a Date field receives a string', () => {
+      const input = {
+         id: 'creator-3',
+         handle: 'test-handle',
+         displayName: 'Alice',
+         avatarUrl: null,
+         isVerified: true,
+         createdAt: '2024-01-02T03:04:05.678Z', // string instead of Date
+         updatedAt: new Date('2024-01-03T03:04:05.678Z'),
+      } as any;
+
+      requestContextStorage.run(
+         { path: '/api/v1/creators', method: 'GET', requestId: 'req-type-2' },
+         () => mapCreatorListItem(input)
+      );
+
+      expect(errorMock).toHaveBeenCalledWith(
+         expect.objectContaining({
+            msg: 'Creator list field type mismatch',
+            fieldName: 'createdAt',
+            expectedType: 'Date',
+            receivedType: 'string',
+            creatorId: 'creator-3',
+            requestId: 'req-type-2',
+         })
+      );
+   });
+
+   it('does not log an error for correctly typed fields', () => {
+      const input = {
+         id: 'creator-4',
+         handle: 'good-handle',
+         displayName: 'Bob',
+         avatarUrl: 'https://example.com/avatar.png',
+         isVerified: false,
+         createdAt: new Date('2024-01-02T03:04:05.678Z'),
+         updatedAt: new Date('2024-01-03T03:04:05.678Z'),
+      } as any;
+
+      mapCreatorListItem(input);
+
+      expect(errorMock).not.toHaveBeenCalled();
    });
 });

--- a/src/modules/creators/creator-list-item.mapper.ts
+++ b/src/modules/creators/creator-list-item.mapper.ts
@@ -35,7 +35,7 @@ function logIfFieldTypeMismatch(
    creator: CreatorProfile,
    fieldName: keyof typeof CREATOR_LIST_FIELD_EXPECTED_TYPES
 ): void {
-   const value = (creator as Record<string, unknown>)[fieldName];
+   const value = (creator as unknown as Record<string, unknown>)[fieldName];
 
    if (value === null || value === undefined) return;
 

--- a/src/modules/creators/creator-list-item.mapper.ts
+++ b/src/modules/creators/creator-list-item.mapper.ts
@@ -17,6 +17,44 @@ export type CreatorListItem = {
    updatedAt: string;
 };
 
+type ExpectedFieldType = 'string' | 'boolean' | 'number' | 'Date';
+
+// Runtime type expectations for fields projected by CREATOR_LIST_DEFAULT_SELECT.
+// A mismatch here signals a DB migration changed a column type without updating the mapping.
+const CREATOR_LIST_FIELD_EXPECTED_TYPES: Record<string, ExpectedFieldType> = {
+   id: 'string',
+   handle: 'string',
+   displayName: 'string',
+   avatarUrl: 'string',
+   isVerified: 'boolean',
+   createdAt: 'Date',
+   updatedAt: 'Date',
+};
+
+function logIfFieldTypeMismatch(
+   creator: CreatorProfile,
+   fieldName: keyof typeof CREATOR_LIST_FIELD_EXPECTED_TYPES
+): void {
+   const value = (creator as Record<string, unknown>)[fieldName];
+
+   if (value === null || value === undefined) return;
+
+   const expectedType = CREATOR_LIST_FIELD_EXPECTED_TYPES[fieldName];
+   const typeMatches =
+      expectedType === 'Date' ? value instanceof Date : typeof value === expectedType;
+
+   if (!typeMatches) {
+      logger.error({
+         msg: 'Creator list field type mismatch',
+         fieldName,
+         expectedType,
+         receivedType: value instanceof Date ? 'Date' : typeof value,
+         creatorId: creator.id,
+         requestId: requestContextStorage.getStore()?.requestId ?? null,
+      });
+   }
+}
+
 function warnIfUnexpectedNullCreatorField(
    creator: CreatorProfile,
    fieldName: 'displayName'
@@ -43,6 +81,14 @@ export const mapCreatorListItem = (
    creator: CreatorProfile
 ): CreatorListItem => {
    warnIfUnexpectedNullCreatorField(creator, 'displayName');
+
+   logIfFieldTypeMismatch(creator, 'id');
+   logIfFieldTypeMismatch(creator, 'handle');
+   logIfFieldTypeMismatch(creator, 'displayName');
+   logIfFieldTypeMismatch(creator, 'avatarUrl');
+   logIfFieldTypeMismatch(creator, 'isVerified');
+   logIfFieldTypeMismatch(creator, 'createdAt');
+   logIfFieldTypeMismatch(creator, 'updatedAt');
 
    return {
       id: creator.id,


### PR DESCRIPTION
# Creator List Mapper – Runtime Type Validation

## What's changed

The creator list mapper had no way to detect when a database field came back as the wrong type — for example, a column that used to be a Date silently becoming a string after a migration. By the time that reaches the client, it's either been coerced quietly or caused a runtime error with no useful context in the logs.

This PR adds runtime type checking inside mapCreatorListItem so that any type mismatch on a projected field is caught early and surfaced as a structured error-level log entry — before the bad value reaches the response.

## What was added

logIfFieldTypeMismatch — a new function in creator-list-item.mapper.ts that checks each field from CREATOR_LIST_DEFAULT_SELECT against its expected runtime type (string, boolean, or Date). It skips null/undefined values (those are already handled by the existing null-field warning) and only fires when a non-null value is the wrong type.

The log entry includes fieldName, expectedType, receivedType, creatorId, and requestId for easy correlation in any log aggregator.

Client response behavior is unchanged — the mismatched value still passes through as-is. This is intentional; the log is an early warning signal, not a blocker.

## Tests

Extended creator-list-item.mapper.test.ts with three new cases:

- A string field receiving a number fires the error log with the correct field/type metadata
- A Date field receiving a string fires the error log
- Correctly typed fields produce no error log

The existing null-field warning tests are untouched and still pass.
Closes #404 
