### PR TITLE
test(creator): add integration test ensuring max-length (1000) bio preserved

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,16 +1,16 @@
 // Test environment stub — sets all required env vars before any module loads.
 // Values are non-functional placeholders sufficient for schema validation.
 
-process.env.MODE = 'test';
-process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
-process.env.GMAIL_USER = 'test@example.com';
-process.env.GMAIL_APP_PASSWORD = 'test-password';
-process.env.GOOGLE_CLIENT_ID = 'test-google-client-id';
-process.env.GOOGLE_CLIENT_SECRET = 'test-google-client-secret';
-process.env.BACKEND_URL = 'http://localhost:3000';
-process.env.FRONTEND_URL = 'http://localhost:5173';
-process.env.CLOUDINARY_CLOUD_NAME = 'test-cloud';
-process.env.CLOUDINARY_API_KEY = 'test-api-key';
-process.env.CLOUDINARY_API_SECRET = 'test-api-secret';
-process.env.PAYSTACK_SECRET_KEY = 'test-paystack-secret';
-process.env.APP_SECRET = 'accesslayer_test_secret_key_32_bytes_long_xxxx';
+process.env.MODE ??= 'test';
+process.env.DATABASE_URL ??= 'postgresql://test:test@localhost:5432/test';
+process.env.GMAIL_USER ??= 'test@example.com';
+process.env.GMAIL_APP_PASSWORD ??= 'test-password';
+process.env.GOOGLE_CLIENT_ID ??= 'test-google-client-id';
+process.env.GOOGLE_CLIENT_SECRET ??= 'test-google-client-secret';
+process.env.BACKEND_URL ??= 'http://localhost:3000';
+process.env.FRONTEND_URL ??= 'http://localhost:5173';
+process.env.CLOUDINARY_CLOUD_NAME ??= 'test-cloud';
+process.env.CLOUDINARY_API_KEY ??= 'test-api-key';
+process.env.CLOUDINARY_API_SECRET ??= 'test-api-secret';
+process.env.PAYSTACK_SECRET_KEY ??= 'test-paystack-secret';
+process.env.APP_SECRET ??= 'accesslayer_test_secret_key_32_bytes_long_xxxx';

--- a/src/modules/creator/creator-detail-long-bio.integration.test.ts
+++ b/src/modules/creator/creator-detail-long-bio.integration.test.ts
@@ -1,0 +1,103 @@
+// Integration test: creator detail endpoint — maximum length bio preservation
+
+import { Request, Response } from 'express';
+import { prisma } from '../../utils/prisma.utils';
+import { getCreatorProfileHandler } from './creator-profile.handlers';
+
+const MAX_CREATOR_BIO_LENGTH = 1000;
+const TEST_USER_ID = 'creator-long-bio-user';
+const TEST_CREATOR_HANDLE = 'creator-long-bio';
+const TEST_DISPLAY_NAME = 'Creator With Long Bio';
+const MAX_LENGTH_BIO = 'A'.repeat(MAX_CREATOR_BIO_LENGTH);
+
+function makeReq(params: Record<string, string> = {}) {
+   return { params } as unknown as Request;
+}
+
+function makeRes() {
+   const headers: Record<string, string> = {};
+   const res: Partial<Response> = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      setHeader: jest.fn().mockImplementation((name: string, value: string) => {
+         headers[name.toLowerCase()] = String(value);
+         return res;
+      }),
+   };
+   return { res: res as Response, headers };
+}
+
+describe('GET /api/v1/creators/:creatorId/profile — max-length bio', () => {
+   let creatorId: string;
+
+   beforeAll(async () => {
+      await prisma.creatorProfile.deleteMany({
+         where: { handle: TEST_CREATOR_HANDLE },
+      });
+      await prisma.user.deleteMany({ where: { id: TEST_USER_ID } });
+
+      await prisma.user.create({
+         data: {
+            id: TEST_USER_ID,
+            email: `${TEST_USER_ID}@example.com`,
+            passwordHash: 'test-password-hash',
+            firstName: 'Long',
+            lastName: 'Bio',
+         },
+      });
+
+      const creatorProfile = await prisma.creatorProfile.create({
+         data: {
+            userId: TEST_USER_ID,
+            handle: TEST_CREATOR_HANDLE,
+            displayName: TEST_DISPLAY_NAME,
+            bio: MAX_LENGTH_BIO,
+         },
+      });
+
+      creatorId = creatorProfile.id;
+   });
+
+   afterAll(async () => {
+      await prisma.creatorProfile.deleteMany({
+         where: { handle: TEST_CREATOR_HANDLE },
+      });
+      await prisma.user.deleteMany({ where: { id: TEST_USER_ID } });
+      await prisma.$disconnect();
+   });
+
+   it('returns the full max-length bio without truncation or serialization error', async () => {
+      const req = makeReq({ creatorId: TEST_CREATOR_HANDLE });
+      const { res, headers } = makeRes();
+
+      await getCreatorProfileHandler(req, res);
+
+      const statusMock = (res.status as jest.Mock).mock;
+      const jsonMock = res.json as jest.Mock;
+
+      expect(statusMock.calls[0]?.[0]).toBe(200);
+      expect(jsonMock).toHaveBeenCalledWith(
+         expect.objectContaining({
+            success: true,
+            data: expect.objectContaining({
+               creatorId,
+               displayName: TEST_DISPLAY_NAME,
+               bio: MAX_LENGTH_BIO,
+               avatarUrl: null,
+               createdAt: expect.any(String),
+               updatedAt: expect.any(String),
+               perks: [],
+               links: [],
+               metadata: {
+                  source: 'database',
+                  isProfileComplete: true,
+               },
+            }),
+         })
+      );
+
+      const body = jsonMock.mock.calls[0][0];
+      expect(body.data.bio).toHaveLength(MAX_CREATOR_BIO_LENGTH);
+      expect(headers['content-type']).toBe('application/json');
+   });
+});


### PR DESCRIPTION
Close #395 


# Add integration test for creator detail with max-length bio

Summary
- Adds an integration test that seeds a creator profile with a 1000-character bio and verifies the GET /api/v1/creators/:creatorId/profile response returns the full bio without truncation or serialization errors.
- Documents the maximum bio length as the named constant `MAX_CREATOR_BIO_LENGTH = 1000` within the test.
- Uses the handler directly to avoid unnecessary app-level dependencies in the test environment and asserts response shape and headers.

Files changed (summary)
- Added: creator-detail-long-bio.integration.test.ts
- Minor update: jest.setup.ts — make test env defaults non-destructive to allow overriding `DATABASE_URL` during CI/local runs.

Why
- A creator bio near the maximum allowed length exercises serialization and response handling code paths. This regression test prevents accidental truncation, serialization failures, or response-shape regressions as the codebase evolves.

What I verified locally
- Installed dependencies and generated Prisma client.
- Started local Postgres via `docker compose up -d postgres`.
- Pushed Prisma schema:  
  `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/accesslayer' pnpm exec prisma db push`
- Ran the test successfully:  
  `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/accesslayer' pnpm exec jest creator-detail-long-bio.integration.test.ts --runInBand`

Testing Notes / Deployment
- CI must run the test with a database available (the project uses `prisma db push` or migrations to create schema). For CI, ensure `DATABASE_URL` points to the test DB and the DB is provisioned before tests run.
- The test intentionally uses a 1000-char constant to reflect the Zod schema limit in creator-profile.schemas.ts. If that limit changes, update the test constant to match.

