### PR TITLE
refactor: add creator param not-found helper

### DIFF
--- a/src/modules/admin/admin.controllers.ts
+++ b/src/modules/admin/admin.controllers.ts
@@ -2,7 +2,7 @@ import { AsyncController } from '../../types/auth.types';
 import {
    sendSuccess,
    sendValidationError,
-   sendNotFound,
+   sendCreatorParamNotFound,
    sendForbidden,
 } from '../../utils/api-response.utils';
 import { prisma } from '../../utils/prisma.utils';
@@ -61,7 +61,7 @@ export const httpUpdateCreatorMetadata: AsyncController = async (
       });
 
       if (!creator) {
-         return sendNotFound(res, 'Creator');
+         return sendCreatorParamNotFound(res);
       }
 
       const previousValues = {

--- a/src/utils/api-response.utils.ts
+++ b/src/utils/api-response.utils.ts
@@ -187,6 +187,10 @@ export function sendNotFound(res: Response, resource: string): void {
    sendError(res, 404, ErrorCode.NOT_FOUND, `${resource} not found`);
 }
 
+export function sendCreatorParamNotFound(res: Response): void {
+   sendNotFound(res, 'Creator');
+}
+
 export function sendUnauthorized(
    res: Response,
    message = 'Unauthorized access',

--- a/src/utils/test/api-response.utils.test.ts
+++ b/src/utils/test/api-response.utils.test.ts
@@ -2,6 +2,7 @@ import { Response } from 'express';
 import {
    sendForbidden,
    sendUnauthorized,
+   sendCreatorParamNotFound,
    buildErrorResponse,
    zodIssuesToDetails,
    ErrorCode,
@@ -17,6 +18,7 @@ describe('api-response.utils', () => {
       jsonMock = jest.fn();
       statusMock = jest.fn().mockReturnValue({ json: jsonMock });
       mockResponse = {
+         setHeader: jest.fn(),
          status: statusMock,
       };
    });
@@ -61,6 +63,21 @@ describe('api-response.utils', () => {
             error: {
                code: ErrorCode.UNAUTHORIZED,
                message: 'Unauthorized access',
+            },
+         });
+      });
+   });
+
+   describe('sendCreatorParamNotFound', () => {
+      it('should send the shared creator parameter not-found response', () => {
+         sendCreatorParamNotFound(mockResponse as Response);
+
+         expect(statusMock).toHaveBeenCalledWith(404);
+         expect(jsonMock).toHaveBeenCalledWith({
+            success: false,
+            error: {
+               code: ErrorCode.NOT_FOUND,
+               message: 'Creator not found',
             },
          });
       });


### PR DESCRIPTION
Fixes #46

## Summary
- add `sendCreatorParamNotFound` as the reusable creator-param not-found shortcut
- adopt it in the creator metadata route instead of spelling out the generic resource helper there
- add focused response-helper coverage for the exact 404 payload

## Test plan
- `pnpm test -- src/utils/test/api-response.utils.test.ts --runInBand`
- `pnpm exec prisma generate && pnpm exec tsc --noEmit`
- `pnpm lint -- src/utils/api-response.utils.ts src/utils/test/api-response.utils.test.ts src/modules/admin/admin.controllers.ts`
