### PR TITLE
feat(creator): add sendCreatorNotFound 404 helper (#101)

### DIFF
--- a/src/modules/creator/creator-not-found.utils.test.ts
+++ b/src/modules/creator/creator-not-found.utils.test.ts
@@ -1,0 +1,42 @@
+// src/modules/creator/creator-not-found.utils.test.ts
+import { sendCreatorNotFound } from './creator-not-found.utils';
+import { sendError } from '../../utils/api-response.utils';
+import { ErrorCode } from '../../constants/error.constants';
+
+jest.mock('../../utils/api-response.utils', () => ({
+  sendError: jest.fn(),
+}));
+
+function makeRes(): any {
+  return { status: jest.fn().mockReturnThis(), json: jest.fn() };
+}
+
+describe('sendCreatorNotFound', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('calls sendError with status 404', () => {
+    const res = makeRes();
+    sendCreatorNotFound(res);
+    expect(sendError).toHaveBeenCalledWith(
+      res,
+      404,
+      ErrorCode.NOT_FOUND,
+      'Creator not found'
+    );
+  });
+
+  it('uses the NOT_FOUND error code from shared constants', () => {
+    const res = makeRes();
+    sendCreatorNotFound(res);
+    const [, , code] = (sendError as jest.Mock).mock.calls[0];
+    expect(code).toBe(ErrorCode.NOT_FOUND);
+  });
+
+  it('returns void', () => {
+    const res = makeRes();
+    const result = sendCreatorNotFound(res);
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/modules/creator/creator-not-found.utils.ts
+++ b/src/modules/creator/creator-not-found.utils.ts
@@ -1,0 +1,24 @@
+// src/modules/creator/creator-not-found.utils.ts
+import { Response } from 'express';
+import { sendError } from '../../utils/api-response.utils';
+import { ErrorCode } from '../../constants/error.constants';
+
+/**
+ * Sends a consistent 404 JSON response for creator route endpoints.
+ *
+ * Centralises the not-found payload so every creator handler returns
+ * the same status code, error code, and message without duplicating
+ * the `sendError` call inline.
+ *
+ * @param res - Express Response object
+ *
+ * @example
+ * const creator = await findCreatorById(id);
+ * if (!creator) {
+ *   sendCreatorNotFound(res);
+ *   return;
+ * }
+ */
+export function sendCreatorNotFound(res: Response): void {
+  sendError(res, 404, ErrorCode.NOT_FOUND, 'Creator not found');
+}


### PR DESCRIPTION
## Summary

-

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm build`
- [ ] `pnpm exec prisma generate` when schema or generated types changed

## Checklist

- [ ] Linked issue or backlog item
- [ ] No secrets or live credentials added
- [ ] Docs updated if setup or env changed
- [ ] Change is scoped to one problem
closes #101