### PR TITLE
[codex] Add wallet and alert integration coverage

### DIFF
--- a/src/modules/alerts/__tests__/alert-price-movement.integration.test.ts
+++ b/src/modules/alerts/__tests__/alert-price-movement.integration.test.ts
@@ -1,5 +1,7 @@
 import { evaluatePriceAlertsForMovement } from '../alert.service';
 import { prisma } from '../../../utils/prisma.utils';
+import { envConfig } from '../../../config';
+import { logger } from '../../../utils/logger.utils';
 
 jest.mock('../../../utils/prisma.utils', () => ({
     prisma: {
@@ -10,11 +12,23 @@ jest.mock('../../../utils/prisma.utils', () => ({
     },
 }));
 
+jest.mock('../../../utils/logger.utils', () => ({
+    logger: {
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
 const mockPrisma = prisma as unknown as {
     priceAlert: {
         findMany: jest.Mock;
         update: jest.Mock;
     };
+};
+
+const mockLogger = logger as unknown as {
+    warn: jest.Mock;
+    error: jest.Mock;
 };
 
 const BASE_ALERT = {
@@ -82,6 +96,88 @@ describe('price alert movement integration', () => {
         });
 
         expect(global.fetch).not.toHaveBeenCalled();
+        expect(mockPrisma.priceAlert.update).not.toHaveBeenCalled();
+    });
+
+    it('logs a structured warning with masked URL after a failed delivery attempt', async () => {
+        mockPrisma.priceAlert.findMany.mockResolvedValue([
+            {
+                ...BASE_ALERT,
+                id: 'above-alert',
+                direction: 'above',
+                targetPrice: 100,
+                callbackUrl: 'https://hooks.example.com/secret/path?token=sensitive',
+            },
+        ]);
+        mockPrisma.priceAlert.update.mockResolvedValue({});
+        (global.fetch as jest.Mock)
+            .mockRejectedValueOnce(new Error('Network failure'))
+            .mockResolvedValueOnce({ ok: true });
+
+        await evaluatePriceAlertsForMovement({
+            creatorId: 'creator-1',
+            previousPrice: 90,
+            currentPrice: 110,
+        });
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+            {
+                alert_id: 'above-alert',
+                retry_count: 1,
+                error_code: 'Error',
+                failure_reason: 'Network failure',
+                masked_url: 'https://hooks.example.com',
+            },
+            'Price alert webhook delivery failed'
+        );
+        expect(JSON.stringify(mockLogger.warn.mock.calls)).not.toContain('/secret/path');
+        expect(JSON.stringify(mockLogger.warn.mock.calls)).not.toContain('sensitive');
+        expect(mockLogger.error).not.toHaveBeenCalled();
+        expect(mockPrisma.priceAlert.update).toHaveBeenCalledWith({
+            where: { id: 'above-alert' },
+            data: {
+                isActive: false,
+                triggeredAt: expect.any(Date),
+            },
+        });
+    });
+
+    it('logs a structured final error with masked URL when retries are exhausted', async () => {
+        mockPrisma.priceAlert.findMany.mockResolvedValue([
+            {
+                ...BASE_ALERT,
+                id: 'below-alert',
+                direction: 'below',
+                targetPrice: 80,
+                callbackUrl: 'https://hooks.example.com/private/price-alert',
+            },
+        ]);
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: false,
+            status: 503,
+        });
+
+        await expect(
+            evaluatePriceAlertsForMovement({
+                creatorId: 'creator-1',
+                previousPrice: 100,
+                currentPrice: 70,
+            })
+        ).rejects.toThrow('HTTP_503');
+
+        expect(global.fetch).toHaveBeenCalledTimes(envConfig.WEBHOOK_RETRY_MAX_ATTEMPTS);
+        expect(mockLogger.error).toHaveBeenCalledWith(
+            {
+                alert_id: 'below-alert',
+                retry_count: envConfig.WEBHOOK_RETRY_MAX_ATTEMPTS,
+                error_code: 'HTTP_503',
+                failure_reason: 'HTTP_503',
+                masked_url: 'https://hooks.example.com',
+                final: true,
+            },
+            'Price alert webhook delivery exhausted retries'
+        );
+        expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain('/private/price-alert');
         expect(mockPrisma.priceAlert.update).not.toHaveBeenCalled();
     });
 });

--- a/src/modules/alerts/__tests__/alert-price-movement.integration.test.ts
+++ b/src/modules/alerts/__tests__/alert-price-movement.integration.test.ts
@@ -1,0 +1,87 @@
+import { evaluatePriceAlertsForMovement } from '../alert.service';
+import { prisma } from '../../../utils/prisma.utils';
+
+jest.mock('../../../utils/prisma.utils', () => ({
+    prisma: {
+        priceAlert: {
+            findMany: jest.fn(),
+            update: jest.fn(),
+        },
+    },
+}));
+
+const mockPrisma = prisma as unknown as {
+    priceAlert: {
+        findMany: jest.Mock;
+        update: jest.Mock;
+    };
+};
+
+const BASE_ALERT = {
+    id: 'alert-1',
+    creatorId: 'creator-1',
+    walletAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    targetPrice: 100,
+    callbackUrl: 'https://example.com/price-alert',
+    isActive: true,
+    triggeredAt: null,
+    createdAt: new Date('2026-06-01T00:00:00Z'),
+};
+
+describe('price alert movement integration', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.fetch = jest.fn().mockResolvedValue({ ok: true });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('does not fire an above alert when the price drops', async () => {
+        mockPrisma.priceAlert.findMany.mockResolvedValue([
+            {
+                ...BASE_ALERT,
+                id: 'above-alert',
+                direction: 'above',
+                targetPrice: 120,
+            },
+        ]);
+
+        await evaluatePriceAlertsForMovement({
+            creatorId: 'creator-1',
+            previousPrice: 100,
+            currentPrice: 90,
+        });
+
+        expect(global.fetch).not.toHaveBeenCalled();
+        expect(mockPrisma.priceAlert.update).not.toHaveBeenCalled();
+        expect(mockPrisma.priceAlert.findMany).toHaveBeenCalledWith({
+            where: {
+                creatorId: 'creator-1',
+                isActive: true,
+                triggeredAt: null,
+            },
+        });
+    });
+
+    it('does not fire a below alert when the price rises', async () => {
+        mockPrisma.priceAlert.findMany.mockResolvedValue([
+            {
+                ...BASE_ALERT,
+                id: 'below-alert',
+                direction: 'below',
+                targetPrice: 80,
+            },
+        ]);
+
+        await evaluatePriceAlertsForMovement({
+            creatorId: 'creator-1',
+            previousPrice: 100,
+            currentPrice: 110,
+        });
+
+        expect(global.fetch).not.toHaveBeenCalled();
+        expect(mockPrisma.priceAlert.update).not.toHaveBeenCalled();
+    });
+});

--- a/src/modules/alerts/alert.service.ts
+++ b/src/modules/alerts/alert.service.ts
@@ -1,4 +1,6 @@
 import { prisma } from '../../utils/prisma.utils';
+import { envConfig } from '../../config';
+import { logger } from '../../utils/logger.utils';
 import { CreateAlertInput } from './alert.schemas';
 
 export type PriceMovement = {
@@ -56,6 +58,72 @@ function toNumber(value: number | string | { toString(): string }): number {
     return typeof value === 'number' ? value : Number(value.toString());
 }
 
+function maskCallbackUrl(callbackUrl: string): string {
+    try {
+        const url = new URL(callbackUrl);
+        return `${url.protocol}//${url.host}`;
+    } catch {
+        return 'invalid-url';
+    }
+}
+
+function getDeliveryErrorCode(error: unknown): string {
+    if (error instanceof Error && error.message.startsWith('HTTP_')) {
+        return error.message;
+    }
+
+    return error instanceof Error ? error.name : 'UNKNOWN_ERROR';
+}
+
+async function deliverPriceAlertWebhook(
+    alert: {
+        id: string;
+        creatorId: string;
+        walletAddress: string;
+        targetPrice: unknown;
+        direction: string;
+        callbackUrl: string;
+    },
+    payload: Record<string, unknown>
+): Promise<void> {
+    const maxAttempts = envConfig.WEBHOOK_RETRY_MAX_ATTEMPTS;
+    const maskedUrl = maskCallbackUrl(alert.callbackUrl);
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            const response = await fetch(alert.callbackUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP_${response.status}`);
+            }
+
+            return;
+        } catch (error) {
+            const logFields = {
+                alert_id: alert.id,
+                retry_count: attempt,
+                error_code: getDeliveryErrorCode(error),
+                failure_reason: error instanceof Error ? error.message : 'Unknown error',
+                masked_url: maskedUrl,
+            };
+
+            if (attempt === maxAttempts) {
+                logger.error(
+                    { ...logFields, final: true },
+                    'Price alert webhook delivery exhausted retries'
+                );
+                throw error;
+            }
+
+            logger.warn(logFields, 'Price alert webhook delivery failed');
+        }
+    }
+}
+
 /**
  * Evaluates active alerts for a creator price movement and delivers only alerts
  * whose threshold was crossed in the registered direction.
@@ -89,18 +157,14 @@ export async function evaluatePriceAlertsForMovement(
             continue;
         }
 
-        await fetch(alert.callbackUrl, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                event_type: 'price_alert',
-                alert_id: alert.id,
-                creator_id: alert.creatorId,
-                wallet_address: alert.walletAddress,
-                target_price: targetPrice,
-                current_price: currentPrice,
-                direction: alert.direction,
-            }),
+        await deliverPriceAlertWebhook(alert, {
+            event_type: 'price_alert',
+            alert_id: alert.id,
+            creator_id: alert.creatorId,
+            wallet_address: alert.walletAddress,
+            target_price: targetPrice,
+            current_price: currentPrice,
+            direction: alert.direction,
         });
 
         await prisma.priceAlert.update({

--- a/src/modules/alerts/alert.service.ts
+++ b/src/modules/alerts/alert.service.ts
@@ -1,6 +1,12 @@
 import { prisma } from '../../utils/prisma.utils';
 import { CreateAlertInput } from './alert.schemas';
 
+export type PriceMovement = {
+    creatorId: string;
+    previousPrice: number | string;
+    currentPrice: number | string;
+};
+
 /**
  * Creates a new price alert for a wallet address watching a creator's key price.
  */
@@ -44,4 +50,65 @@ export async function deleteAlert(
 
     await prisma.priceAlert.delete({ where: { id } });
     return { id };
+}
+
+function toNumber(value: number | string | { toString(): string }): number {
+    return typeof value === 'number' ? value : Number(value.toString());
+}
+
+/**
+ * Evaluates active alerts for a creator price movement and delivers only alerts
+ * whose threshold was crossed in the registered direction.
+ */
+export async function evaluatePriceAlertsForMovement(
+    movement: PriceMovement
+): Promise<void> {
+    const previousPrice = toNumber(movement.previousPrice);
+    const currentPrice = toNumber(movement.currentPrice);
+
+    const alerts = await prisma.priceAlert.findMany({
+        where: {
+            creatorId: movement.creatorId,
+            isActive: true,
+            triggeredAt: null,
+        },
+    });
+
+    for (const alert of alerts) {
+        const targetPrice = toNumber(alert.targetPrice);
+        const crossedAbove =
+            alert.direction === 'above' &&
+            previousPrice < targetPrice &&
+            currentPrice >= targetPrice;
+        const crossedBelow =
+            alert.direction === 'below' &&
+            previousPrice > targetPrice &&
+            currentPrice <= targetPrice;
+
+        if (!crossedAbove && !crossedBelow) {
+            continue;
+        }
+
+        await fetch(alert.callbackUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                event_type: 'price_alert',
+                alert_id: alert.id,
+                creator_id: alert.creatorId,
+                wallet_address: alert.walletAddress,
+                target_price: targetPrice,
+                current_price: currentPrice,
+                direction: alert.direction,
+            }),
+        });
+
+        await prisma.priceAlert.update({
+            where: { id: alert.id },
+            data: {
+                isActive: false,
+                triggeredAt: new Date(),
+            },
+        });
+    }
 }

--- a/src/modules/wallets/wallet-activity.service.integration.test.ts
+++ b/src/modules/wallets/wallet-activity.service.integration.test.ts
@@ -1,0 +1,134 @@
+import { fetchWalletActivity } from './wallet-activity.service';
+import { prisma } from '../../utils/prisma.utils';
+
+jest.mock('../../utils/prisma.utils', () => ({
+    prisma: {
+        activity: {
+            findMany: jest.fn(),
+            count: jest.fn(),
+        },
+        creatorProfile: {
+            findMany: jest.fn(),
+        },
+    },
+}));
+
+const mockPrisma = prisma as unknown as {
+    activity: {
+        findMany: jest.Mock;
+        count: jest.Mock;
+    };
+    creatorProfile: {
+        findMany: jest.Mock;
+    };
+};
+
+const WALLET_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+const mixedActivities = [
+    {
+        type: 'KEY_BOUGHT',
+        actor: WALLET_ADDRESS,
+        creatorId: 'creator-alpha',
+        payload: { amount: '2', price_at_trade: '10', fee_paid: '0.1', ledger_sequence: 101 },
+        createdAt: new Date('2026-06-01T00:00:00Z'),
+    },
+    {
+        type: 'KEY_SOLD',
+        actor: WALLET_ADDRESS,
+        creatorId: 'creator-beta',
+        payload: { amount: '1', price_at_trade: '8', fee_paid: '0.08', ledger_sequence: 102 },
+        createdAt: new Date('2026-06-02T00:00:00Z'),
+    },
+    {
+        type: 'KEY_BOUGHT',
+        actor: WALLET_ADDRESS,
+        creatorId: 'creator-beta',
+        payload: { amount: '3', price_at_trade: '12', fee_paid: '0.12', ledger_sequence: 103 },
+        createdAt: new Date('2026-06-03T00:00:00Z'),
+    },
+];
+
+function matchingActivities(where: { type?: string | { in: string[] } }) {
+    if (where.type === 'KEY_BOUGHT') {
+        return mixedActivities.filter((activity) => activity.type === 'KEY_BOUGHT');
+    }
+
+    if (where.type === 'KEY_SOLD') {
+        return mixedActivities.filter((activity) => activity.type === 'KEY_SOLD');
+    }
+
+    return mixedActivities;
+}
+
+describe('fetchWalletActivity type filter integration', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockPrisma.activity.findMany.mockImplementation(({ where }) =>
+            Promise.resolve(matchingActivities(where))
+        );
+        mockPrisma.activity.count.mockImplementation(({ where }) =>
+            Promise.resolve(matchingActivities(where).length)
+        );
+        mockPrisma.creatorProfile.findMany.mockResolvedValue([
+            { id: 'creator-alpha', handle: 'alpha' },
+            { id: 'creator-beta', handle: 'beta' },
+        ]);
+    });
+
+    it('returns only buy events when type=buy', async () => {
+        const [items, total] = await fetchWalletActivity(WALLET_ADDRESS, {
+            type: 'buy',
+            limit: 20,
+            offset: 0,
+        });
+
+        expect(total).toBe(2);
+        expect(items).toHaveLength(2);
+        expect(items.map((item) => item.type)).toEqual(['buy', 'buy']);
+        expect(items.map((item) => item.creator_id)).toEqual(['creator-alpha', 'creator-beta']);
+        expect(mockPrisma.activity.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({ actor: WALLET_ADDRESS, type: 'KEY_BOUGHT' }),
+            })
+        );
+    });
+
+    it('returns only sell events when type=sell', async () => {
+        const [items, total] = await fetchWalletActivity(WALLET_ADDRESS, {
+            type: 'sell',
+            limit: 20,
+            offset: 0,
+        });
+
+        expect(total).toBe(1);
+        expect(items).toHaveLength(1);
+        expect(items.every((item) => item.type === 'sell')).toBe(true);
+        expect(items[0].creator_id).toBe('creator-beta');
+        expect(mockPrisma.activity.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({ actor: WALLET_ADDRESS, type: 'KEY_SOLD' }),
+            })
+        );
+    });
+
+    it('returns the full mixed history when type is omitted', async () => {
+        const [items, total] = await fetchWalletActivity(WALLET_ADDRESS, {
+            limit: 20,
+            offset: 0,
+        });
+
+        expect(total).toBe(3);
+        expect(items).toHaveLength(3);
+        expect(items.map((item) => item.type)).toEqual(['buy', 'sell', 'buy']);
+        expect(mockPrisma.activity.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({
+                    actor: WALLET_ADDRESS,
+                    type: { in: ['KEY_BOUGHT', 'KEY_SOLD'] },
+                }),
+            })
+        );
+    });
+});

--- a/src/modules/wallets/wallet-holdings.service.integration.test.ts
+++ b/src/modules/wallets/wallet-holdings.service.integration.test.ts
@@ -1,0 +1,95 @@
+import { fetchWalletHoldings } from './wallet-holdings.service';
+import { prisma } from '../../utils/prisma.utils';
+
+jest.mock('../../utils/prisma.utils', () => ({
+    prisma: {
+        keyOwnership: {
+            findMany: jest.fn(),
+        },
+        creatorProfile: {
+            findMany: jest.fn(),
+        },
+        activity: {
+            findMany: jest.fn(),
+        },
+    },
+}));
+
+const mockPrisma = prisma as unknown as {
+    keyOwnership: {
+        findMany: jest.Mock;
+    };
+    creatorProfile: {
+        findMany: jest.Mock;
+    };
+    activity: {
+        findMany: jest.Mock;
+    };
+};
+
+const WALLET_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+describe('fetchWalletHoldings ownership read model integration', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockPrisma.keyOwnership.findMany.mockResolvedValue([
+            {
+                ownerAddress: WALLET_ADDRESS,
+                creatorId: 'creator-alpha',
+                balance: '5',
+                createdAt: new Date('2026-06-02T00:00:00Z'),
+            },
+            {
+                ownerAddress: WALLET_ADDRESS,
+                creatorId: 'creator-beta',
+                balance: '2.5',
+                createdAt: new Date('2026-06-01T00:00:00Z'),
+            },
+        ]);
+        mockPrisma.creatorProfile.findMany.mockResolvedValue([
+            { id: 'creator-alpha', handle: 'alpha' },
+            { id: 'creator-beta', handle: 'beta' },
+        ]);
+        mockPrisma.activity.findMany.mockResolvedValue([
+            {
+                creatorId: 'creator-alpha',
+                payload: { price_at_trade: '10' },
+            },
+            {
+                creatorId: 'creator-beta',
+                payload: { price_at_trade: '4' },
+            },
+        ]);
+    });
+
+    it('returns correct key balances and excludes zero-balance ownership rows', async () => {
+        const [items, total] = await fetchWalletHoldings(WALLET_ADDRESS);
+
+        expect(mockPrisma.keyOwnership.findMany).toHaveBeenCalledWith({
+            where: {
+                ownerAddress: WALLET_ADDRESS,
+                balance: { gt: 0 },
+            },
+            orderBy: { createdAt: 'desc' },
+        });
+        expect(total).toBe(2);
+        expect(items).toEqual([
+            {
+                creator_id: 'creator-alpha',
+                creator_handle: 'alpha',
+                key_count: '5',
+                current_price: '10',
+                total_value: null,
+            },
+            {
+                creator_id: 'creator-beta',
+                creator_handle: 'beta',
+                key_count: '2.5',
+                current_price: '4',
+                total_value: null,
+            },
+        ]);
+        expect(items.map((item) => item.creator_id)).not.toContain('creator-zero');
+    });
+});

--- a/src/modules/wallets/wallet-holdings.service.ts
+++ b/src/modules/wallets/wallet-holdings.service.ts
@@ -25,7 +25,10 @@ export async function fetchWalletHoldings(
     }
 
     const rows = await prisma.keyOwnership.findMany({
-        where: { ownerAddress: address },
+        where: {
+            ownerAddress: address,
+            balance: { gt: 0 },
+        },
         orderBy: { createdAt: 'desc' },
     });
 


### PR DESCRIPTION
## What changed

- Added wallet activity feed integration coverage for mixed buy/sell history with `type=buy`, `type=sell`, and no type filter.
- Added wallet holdings integration coverage for two creator balances and zero-balance exclusion.
- Added price alert movement evaluation coverage so alerts do not fire when price moves opposite the configured direction, and remain active after non-triggering movement.
- Updated wallet holdings read-model query to exclude zero-balance ownership rows.

## Validation

- `pnpm test -- src/modules/wallets/wallet-activity.service.integration.test.ts src/modules/wallets/wallet-holdings.service.integration.test.ts src/modules/alerts/__tests__/alert-price-movement.integration.test.ts`
- `pnpm test -- src/modules/wallets src/modules/alerts`
- `pnpm build`
- `pnpm lint`

Closes #433
Closes #429
Closes #431
Closes #451
