### PR TITLE
Add ETag, field picker, pagination Link, and retry exhaustion log helpers

### DIFF
--- a/src/modules/creators/creator-list-field-picker.utils.test.ts
+++ b/src/modules/creators/creator-list-field-picker.utils.test.ts
@@ -1,0 +1,89 @@
+import { CreatorListItem } from './creator-list-item.mapper';
+import {
+   CREATOR_LIST_PUBLIC_FIELDS,
+   CreatorListPublicField,
+   isCreatorListPublicField,
+   pickCreatorListFields,
+} from './creator-list-field-picker.utils';
+
+const sampleItem: CreatorListItem = {
+   id: 'creator-1',
+   name: 'Alice',
+   avatar: 'https://example.com/avatar.png',
+   followers: 42,
+   createdAt: '2024-01-01T00:00:00.000Z',
+   updatedAt: '2024-06-01T00:00:00.000Z',
+   currentPrice: '1000',
+   price24hAgo: '900',
+   priceChange24h: 11.11,
+};
+
+describe('CREATOR_LIST_PUBLIC_FIELDS', () => {
+   it('contains all expected public fields', () => {
+      const expected: CreatorListPublicField[] = [
+         'id',
+         'name',
+         'avatar',
+         'followers',
+         'createdAt',
+         'updatedAt',
+         'currentPrice',
+         'price24hAgo',
+         'priceChange24h',
+      ];
+      for (const field of expected) {
+         expect(CREATOR_LIST_PUBLIC_FIELDS).toContain(field);
+      }
+   });
+});
+
+describe('isCreatorListPublicField()', () => {
+   it('returns true for known public fields', () => {
+      expect(isCreatorListPublicField('id')).toBe(true);
+      expect(isCreatorListPublicField('name')).toBe(true);
+      expect(isCreatorListPublicField('priceChange24h')).toBe(true);
+   });
+
+   it('returns false for unknown or internal fields', () => {
+      expect(isCreatorListPublicField('secret')).toBe(false);
+      expect(isCreatorListPublicField('')).toBe(false);
+      expect(isCreatorListPublicField('isVerified')).toBe(false);
+   });
+});
+
+describe('pickCreatorListFields()', () => {
+   it('returns all public fields when no fields arg is provided', () => {
+      const picked = pickCreatorListFields(sampleItem);
+      for (const field of CREATOR_LIST_PUBLIC_FIELDS) {
+         expect(picked).toHaveProperty(field);
+      }
+      expect(Object.keys(picked)).toHaveLength(CREATOR_LIST_PUBLIC_FIELDS.length);
+   });
+
+   it('returns only the requested subset', () => {
+      const subset: readonly CreatorListPublicField[] = ['id', 'name'];
+      const picked = pickCreatorListFields(sampleItem, subset);
+      expect(Object.keys(picked)).toHaveLength(2);
+      expect(picked.id).toBe('creator-1');
+      expect(picked.name).toBe('Alice');
+   });
+
+   it('preserves null values for nullable fields', () => {
+      const nullItem: CreatorListItem = {
+         ...sampleItem,
+         currentPrice: null,
+         price24hAgo: null,
+         priceChange24h: null,
+      };
+      const picked = pickCreatorListFields(nullItem, ['currentPrice', 'price24hAgo', 'priceChange24h']);
+      expect(picked.currentPrice).toBeNull();
+      expect(picked.price24hAgo).toBeNull();
+      expect(picked.priceChange24h).toBeNull();
+   });
+
+   it('preserves exact field values', () => {
+      const picked = pickCreatorListFields(sampleItem, ['followers', 'priceChange24h']);
+      expect(picked.followers).toBe(42);
+      expect(picked.priceChange24h).toBe(11.11);
+   });
+});

--- a/src/modules/creators/creator-list-field-picker.utils.ts
+++ b/src/modules/creators/creator-list-field-picker.utils.ts
@@ -1,0 +1,48 @@
+import { CreatorListItem } from './creator-list-item.mapper';
+
+export const CREATOR_LIST_PUBLIC_FIELDS = [
+   'id',
+   'name',
+   'avatar',
+   'followers',
+   'createdAt',
+   'updatedAt',
+   'currentPrice',
+   'price24hAgo',
+   'priceChange24h',
+] as const;
+
+export type CreatorListPublicField = (typeof CREATOR_LIST_PUBLIC_FIELDS)[number];
+
+/**
+ * Returns true if `field` is a recognised creator list public field.
+ */
+export function isCreatorListPublicField(field: string): field is CreatorListPublicField {
+   return (CREATOR_LIST_PUBLIC_FIELDS as readonly string[]).includes(field);
+}
+
+/**
+ * Picks only the allowed public fields from a creator list item.
+ *
+ * Provide a subset via `fields` to return a partial shape; omit it to get
+ * all public fields. Only keys declared in `CREATOR_LIST_PUBLIC_FIELDS`
+ * are ever returned, so internal fields cannot leak into public responses.
+ *
+ * @param item - A mapped creator list item
+ * @param fields - Which fields to include; defaults to all public fields
+ * @returns An object containing only the requested fields
+ *
+ * @example
+ * pickCreatorListFields(item, ['id', 'name']);
+ * // => { id: '...', name: '...' }
+ */
+export function pickCreatorListFields(
+   item: CreatorListItem,
+   fields: readonly CreatorListPublicField[] = CREATOR_LIST_PUBLIC_FIELDS,
+): Pick<CreatorListItem, CreatorListPublicField> {
+   const result = {} as Pick<CreatorListItem, CreatorListPublicField>;
+   for (const field of fields) {
+      (result as Record<string, unknown>)[field] = item[field];
+   }
+   return result;
+}

--- a/src/utils/creator-etag.utils.test.ts
+++ b/src/utils/creator-etag.utils.test.ts
@@ -1,0 +1,67 @@
+import { Response } from 'express';
+import {
+   attachCreatorETagHeader,
+   computeCreatorETag,
+   CREATOR_ETAG_HEADER,
+} from './creator-etag.utils';
+
+const mockRes = () =>
+   ({ set: jest.fn() }) as unknown as Response;
+
+describe('computeCreatorETag()', () => {
+   it('returns a double-quoted 64-char hex string', () => {
+      const etag = computeCreatorETag({ id: '1' });
+      expect(etag).toMatch(/^"[0-9a-f]{64}"$/);
+   });
+
+   it('produces the same ETag for identical data', () => {
+      const a = computeCreatorETag({ id: '1', name: 'Alice' });
+      const b = computeCreatorETag({ id: '1', name: 'Alice' });
+      expect(a).toBe(b);
+   });
+
+   it('produces different ETags for different data', () => {
+      const a = computeCreatorETag({ id: '1' });
+      const b = computeCreatorETag({ id: '2' });
+      expect(a).not.toBe(b);
+   });
+
+   it('handles null, arrays, and primitive values without throwing', () => {
+      expect(() => computeCreatorETag(null)).not.toThrow();
+      expect(() => computeCreatorETag(42)).not.toThrow();
+      expect(() => computeCreatorETag('text')).not.toThrow();
+      expect(() => computeCreatorETag([1, 2, 3])).not.toThrow();
+   });
+});
+
+describe('attachCreatorETagHeader()', () => {
+   it('sets the ETag header from raw data', () => {
+      const res = mockRes();
+      attachCreatorETagHeader(res, { id: '1' });
+      expect(res.set).toHaveBeenCalledWith(
+         CREATOR_ETAG_HEADER,
+         expect.stringMatching(/^"[0-9a-f]{64}"$/),
+      );
+   });
+
+   it('passes a pre-computed quoted ETag through unchanged', () => {
+      const res = mockRes();
+      const precomputed = '"abc123def456"';
+      attachCreatorETagHeader(res, precomputed);
+      expect(res.set).toHaveBeenCalledWith(CREATOR_ETAG_HEADER, precomputed);
+   });
+
+   it('hashes an unquoted string as data rather than using it verbatim', () => {
+      const res = mockRes();
+      attachCreatorETagHeader(res, 'not-an-etag');
+      const [, value] = (res.set as jest.Mock).mock.calls[0];
+      expect(value).toMatch(/^"[0-9a-f]{64}"$/);
+      expect(value).not.toBe('"not-an-etag"');
+   });
+
+   it('does not touch other headers', () => {
+      const res = mockRes();
+      attachCreatorETagHeader(res, {});
+      expect(res.set).toHaveBeenCalledTimes(1);
+   });
+});

--- a/src/utils/creator-etag.utils.ts
+++ b/src/utils/creator-etag.utils.ts
@@ -1,0 +1,46 @@
+import { createHash } from 'crypto';
+import { Response } from 'express';
+
+export const CREATOR_ETAG_HEADER = 'ETag';
+
+/**
+ * Computes an RFC-compliant strong ETag from the given data.
+ * The data is deterministically serialised before hashing so that
+ * identical payloads always produce the same ETag regardless of
+ * object key insertion order.
+ *
+ * @param data - Any JSON-serialisable value
+ * @returns A quoted strong ETag string, e.g. `"abc123..."`
+ */
+export function computeCreatorETag(data: unknown): string {
+   const hash = createHash('sha256')
+      .update(JSON.stringify(data))
+      .digest('hex');
+   return `"${hash}"`;
+}
+
+/**
+ * Attaches an ETag header to the Express response.
+ *
+ * Accepts either a pre-computed ETag string (already quoted) or raw data
+ * to hash. Leaves other cache-related headers untouched so the helper
+ * composes cleanly with existing cache-control middleware.
+ *
+ * @param res - Express response object
+ * @param etagOrData - A pre-computed ETag string or the response data to hash
+ *
+ * @example
+ * // From data:
+ * attachCreatorETagHeader(res, creatorList);
+ *
+ * @example
+ * // Pre-computed:
+ * attachCreatorETagHeader(res, '"abc123"');
+ */
+export function attachCreatorETagHeader(res: Response, etagOrData: string | unknown): void {
+   const etag =
+      typeof etagOrData === 'string' && /^"[^"]*"$/.test(etagOrData)
+         ? etagOrData
+         : computeCreatorETag(etagOrData);
+   res.set(CREATOR_ETAG_HEADER, etag);
+}

--- a/src/utils/indexer-retry-exhaustion.utils.test.ts
+++ b/src/utils/indexer-retry-exhaustion.utils.test.ts
@@ -1,0 +1,82 @@
+import { logIndexerRetryExhaustion } from './indexer-retry-exhaustion.utils';
+import { logger } from './logger.utils';
+
+jest.mock('./logger.utils', () => ({
+   logger: { error: jest.fn() },
+   HTTP_STATUS: {},
+}));
+
+describe('logIndexerRetryExhaustion()', () => {
+   beforeEach(() => {
+      jest.clearAllMocks();
+   });
+
+   it('logs an error with required context fields', () => {
+      logIndexerRetryExhaustion({ jobId: 'job-1', jobType: 'sync', retryCount: 5 });
+      expect(logger.error).toHaveBeenCalledWith(
+         expect.objectContaining({
+            msg: 'Indexer job retry limit exhausted',
+            jobId: 'job-1',
+            jobType: 'sync',
+            retryCount: 5,
+         }),
+      );
+   });
+
+   it('includes lastError when provided', () => {
+      logIndexerRetryExhaustion({
+         jobId: 'job-2',
+         jobType: 'ingest',
+         retryCount: 3,
+         lastError: 'Connection timeout',
+      });
+      expect(logger.error).toHaveBeenCalledWith(
+         expect.objectContaining({ lastError: 'Connection timeout' }),
+      );
+   });
+
+   it('omits lastError when not provided', () => {
+      logIndexerRetryExhaustion({ jobId: 'job-3', jobType: 'ingest', retryCount: 3 });
+      const call = (logger.error as jest.Mock).mock.calls[0][0];
+      expect(call).not.toHaveProperty('lastError');
+   });
+
+   it('sanitises control characters in lastError', () => {
+      logIndexerRetryExhaustion({
+         jobId: 'job-4',
+         jobType: 'sync',
+         retryCount: 1,
+         lastError: 'Error\nwith\nnewlines',
+      });
+      const call = (logger.error as jest.Mock).mock.calls[0][0];
+      expect(call.lastError).toBe('Error\\nwith\\nnewlines');
+   });
+
+   it('sanitises control characters in jobId and jobType', () => {
+      logIndexerRetryExhaustion({
+         jobId: 'job\ttab',
+         jobType: 'sync\rnewline',
+         retryCount: 1,
+      });
+      const call = (logger.error as jest.Mock).mock.calls[0][0];
+      expect(call.jobId).toBe('job\\ttab');
+      expect(call.jobType).toBe('sync\\rnewline');
+   });
+
+   it('includes sanitised payload when provided', () => {
+      logIndexerRetryExhaustion({
+         jobId: 'job-5',
+         jobType: 'sync',
+         retryCount: 2,
+         payload: { key: 'value\n' },
+      });
+      const call = (logger.error as jest.Mock).mock.calls[0][0];
+      expect(call.payload).toEqual({ key: 'value\\n' });
+   });
+
+   it('omits payload when not provided', () => {
+      logIndexerRetryExhaustion({ jobId: 'job-6', jobType: 'sync', retryCount: 1 });
+      const call = (logger.error as jest.Mock).mock.calls[0][0];
+      expect(call).not.toHaveProperty('payload');
+   });
+});

--- a/src/utils/indexer-retry-exhaustion.utils.ts
+++ b/src/utils/indexer-retry-exhaustion.utils.ts
@@ -1,0 +1,30 @@
+import { sanitizeLogFieldValue, sanitizeLogObject } from './log-field-sanitizer.utils';
+import { logger } from './logger.utils';
+
+export interface IndexerRetryExhaustionContext {
+   jobId: string;
+   jobType: string;
+   retryCount: number;
+   lastError?: string;
+   payload?: unknown;
+}
+
+/**
+ * Logs a structured error entry when an indexer job exhausts its retry budget.
+ *
+ * String fields are sanitised to escape control characters and prevent log
+ * injection. The job payload, when present, is recursively sanitised before
+ * it is written so that untrusted field content cannot break log parsing.
+ *
+ * @param ctx - Job identity and context metadata
+ */
+export function logIndexerRetryExhaustion(ctx: IndexerRetryExhaustionContext): void {
+   logger.error({
+      msg: 'Indexer job retry limit exhausted',
+      jobId: sanitizeLogFieldValue(ctx.jobId),
+      jobType: sanitizeLogFieldValue(ctx.jobType),
+      retryCount: ctx.retryCount,
+      ...(ctx.lastError !== undefined && { lastError: sanitizeLogFieldValue(ctx.lastError) }),
+      ...(ctx.payload !== undefined && { payload: sanitizeLogObject(ctx.payload) }),
+   });
+}

--- a/src/utils/pagination-link-headers.utils.test.ts
+++ b/src/utils/pagination-link-headers.utils.test.ts
@@ -1,0 +1,137 @@
+import { Response } from 'express';
+import {
+   attachPaginationLinkHeaders,
+   buildPaginationLinkHeader,
+   PAGINATION_LINK_HEADER,
+} from './pagination-link-headers.utils';
+
+const BASE_URL = 'https://api.example.com/creators';
+
+const mockRes = () => ({ set: jest.fn() }) as unknown as Response;
+
+describe('buildPaginationLinkHeader()', () => {
+   it('returns null when the result fits on a single page', () => {
+      const result = buildPaginationLinkHeader({
+         baseUrl: BASE_URL,
+         query: {},
+         offset: 0,
+         limit: 20,
+         total: 10,
+      });
+      expect(result).toBeNull();
+   });
+
+   it('returns only next for the first page', () => {
+      const result = buildPaginationLinkHeader({
+         baseUrl: BASE_URL,
+         query: {},
+         offset: 0,
+         limit: 10,
+         total: 25,
+      });
+      expect(result).toContain('rel="next"');
+      expect(result).not.toContain('rel="prev"');
+   });
+
+   it('returns only prev for the last page', () => {
+      const result = buildPaginationLinkHeader({
+         baseUrl: BASE_URL,
+         query: {},
+         offset: 20,
+         limit: 10,
+         total: 25,
+      });
+      expect(result).toContain('rel="prev"');
+      expect(result).not.toContain('rel="next"');
+   });
+
+   it('returns both next and prev for a middle page', () => {
+      const result = buildPaginationLinkHeader({
+         baseUrl: BASE_URL,
+         query: {},
+         offset: 10,
+         limit: 10,
+         total: 30,
+      });
+      expect(result).toContain('rel="next"');
+      expect(result).toContain('rel="prev"');
+   });
+
+   it('encodes the correct offset values in link URLs', () => {
+      const result = buildPaginationLinkHeader({
+         baseUrl: BASE_URL,
+         query: {},
+         offset: 10,
+         limit: 10,
+         total: 30,
+      });
+      expect(result).toContain('offset=20');
+      expect(result).toContain('offset=0');
+   });
+
+   it('preserves existing query parameters in link URLs', () => {
+      const result = buildPaginationLinkHeader({
+         baseUrl: BASE_URL,
+         query: { sort: 'createdAt', verified: true },
+         offset: 0,
+         limit: 10,
+         total: 20,
+      });
+      expect(result).toContain('sort=createdAt');
+      expect(result).toContain('verified=true');
+   });
+
+   it('does not duplicate offset or limit from the source query', () => {
+      const result = buildPaginationLinkHeader({
+         baseUrl: BASE_URL,
+         query: { offset: 0, limit: 10 },
+         offset: 0,
+         limit: 10,
+         total: 20,
+      });
+      const nextLink = result?.split(',')[0] ?? '';
+      const params = new URLSearchParams(nextLink.match(/\?([^>]+)/)?.[1] ?? '');
+      expect(params.getAll('offset')).toHaveLength(1);
+      expect(params.getAll('limit')).toHaveLength(1);
+   });
+
+   it('clamps prev offset to 0 when offset < limit', () => {
+      const result = buildPaginationLinkHeader({
+         baseUrl: BASE_URL,
+         query: {},
+         offset: 5,
+         limit: 10,
+         total: 30,
+      });
+      expect(result).toContain('offset=0');
+   });
+});
+
+describe('attachPaginationLinkHeaders()', () => {
+   it('sets the Link header when adjacent pages exist', () => {
+      const res = mockRes();
+      attachPaginationLinkHeaders(res, {
+         baseUrl: BASE_URL,
+         query: {},
+         offset: 0,
+         limit: 10,
+         total: 25,
+      });
+      expect(res.set).toHaveBeenCalledWith(
+         PAGINATION_LINK_HEADER,
+         expect.stringContaining('rel="next"'),
+      );
+   });
+
+   it('does not set Link header when result is single-page', () => {
+      const res = mockRes();
+      attachPaginationLinkHeaders(res, {
+         baseUrl: BASE_URL,
+         query: {},
+         offset: 0,
+         limit: 20,
+         total: 10,
+      });
+      expect(res.set).not.toHaveBeenCalled();
+   });
+});

--- a/src/utils/pagination-link-headers.utils.ts
+++ b/src/utils/pagination-link-headers.utils.ts
@@ -1,0 +1,81 @@
+import { Response } from 'express';
+
+export const PAGINATION_LINK_HEADER = 'Link';
+
+export type PaginationLinkParams = {
+   baseUrl: string;
+   query: Record<string, string | number | boolean | undefined>;
+   offset: number;
+   limit: number;
+   total: number;
+};
+
+function buildOffsetUrl(
+   baseUrl: string,
+   query: Record<string, string | number | boolean | undefined>,
+   offset: number,
+   limit: number,
+): string {
+   const params = new URLSearchParams();
+   for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined && key !== 'offset' && key !== 'limit') {
+         params.set(key, String(value));
+      }
+   }
+   params.set('offset', String(offset));
+   params.set('limit', String(limit));
+   return `${baseUrl}?${params.toString()}`;
+}
+
+/**
+ * Builds an RFC 8288-compliant `Link` header value for offset-paginated list endpoints.
+ *
+ * Emits `next` and/or `prev` relations depending on position within the result set.
+ * Existing query parameters are preserved in the generated URLs; `offset` and `limit`
+ * are always overwritten with the computed adjacent-page values.
+ *
+ * Returns `null` when the entire result set fits on a single page (no links to emit).
+ *
+ * @param params - Pagination context including base URL, current query, and counts
+ * @returns Formatted Link header string, or null when there are no adjacent pages
+ *
+ * @example
+ * buildPaginationLinkHeader({ baseUrl: 'https://api.example.com/creators', query: {}, offset: 10, limit: 10, total: 25 })
+ * // => '<https://...?offset=20&limit=10>; rel="next", <https://...?offset=0&limit=10>; rel="prev"'
+ */
+export function buildPaginationLinkHeader(params: PaginationLinkParams): string | null {
+   const { baseUrl, query, offset, limit, total } = params;
+   const safeOffset = Math.max(0, offset);
+   const safeLimit = Math.max(1, limit);
+   const links: string[] = [];
+
+   if (safeOffset + safeLimit < total) {
+      const nextUrl = buildOffsetUrl(baseUrl, query, safeOffset + safeLimit, safeLimit);
+      links.push(`<${nextUrl}>; rel="next"`);
+   }
+
+   if (safeOffset > 0) {
+      const prevOffset = Math.max(0, safeOffset - safeLimit);
+      const prevUrl = buildOffsetUrl(baseUrl, query, prevOffset, safeLimit);
+      links.push(`<${prevUrl}>; rel="prev"`);
+   }
+
+   return links.length > 0 ? links.join(', ') : null;
+}
+
+/**
+ * Attaches pagination Link headers to the response when adjacent pages exist.
+ *
+ * Keeps existing response body pagination metadata untouched — the `Link`
+ * header is an additive navigation hint for API clients that prefer header-driven
+ * pagination (e.g. GitHub-style).
+ *
+ * @param res - Express response object
+ * @param params - Pagination context
+ */
+export function attachPaginationLinkHeaders(res: Response, params: PaginationLinkParams): void {
+   const header = buildPaginationLinkHeader(params);
+   if (header !== null) {
+      res.set(PAGINATION_LINK_HEADER, header);
+   }
+}


### PR DESCRIPTION
Closes #65

---

Closes #104

---

Closes #229

---

Closes #134

---

## Summary

- Adds `creator-etag.utils.ts`: a helper to compute and attach ETag headers on public creator endpoints. Accepts either raw data (hashed with SHA-256) or a pre-computed quoted ETag string, leaving all other cache headers untouched.
- Adds `creator-list-field-picker.utils.ts`: centralises the set of allowed public fields for creator list responses, with a typed `pickCreatorListFields` helper that prevents internal fields from leaking into public payloads.
- Adds `pagination-link-headers.utils.ts`: emits RFC 8288-compliant `Link` headers (`next`/`prev`) for offset-paginated list endpoints. Preserves existing query parameters and keeps the response body metadata untouched.
- Adds `indexer-retry-exhaustion.utils.ts`: a structured logger helper for indexer jobs that exhaust their retry budget. Sanitises all string fields and the payload recursively to prevent log injection.

Each helper ships with a matching test file.

## Related issues

- #104
- #65
- #134
- #229