### PR TITLE
Add integration test for wallet holdings total value recalculated after price snapshot update

### DIFF
--- a/src/modules/wallets/wallet-holdings-price-snapshot.integration.test.ts
+++ b/src/modules/wallets/wallet-holdings-price-snapshot.integration.test.ts
@@ -1,0 +1,172 @@
+// Integration test: wallet holdings total value recalculated after price snapshot update (#470)
+//
+// Covers: total_value and current_price reflect the current price snapshot,
+// both update correctly when the snapshot price changes, null when no snapshot exists,
+// and multi-holding aggregation is correct.
+// Uses Jest mocks — no database required.
+
+import { fetchWalletHoldings } from './wallet-holdings.service';
+import { prisma } from '../../utils/prisma.utils';
+
+jest.mock('../../utils/prisma.utils', () => ({
+    prisma: {
+        keyOwnership: {
+            findMany: jest.fn(),
+        },
+        creatorProfile: {
+            findMany: jest.fn(),
+        },
+        creatorPriceSnapshot: {
+            findMany: jest.fn(),
+        },
+    },
+}));
+
+const mockPrisma = prisma as unknown as {
+    keyOwnership: { findMany: jest.Mock };
+    creatorProfile: { findMany: jest.Mock };
+    creatorPriceSnapshot: { findMany: jest.Mock };
+};
+
+const WALLET_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const CREATOR_ID = 'creator-snap-test-1';
+
+describe('Holdings total_value recalculated after price snapshot update', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockPrisma.keyOwnership.findMany.mockResolvedValue([
+            {
+                ownerAddress: WALLET_ADDRESS,
+                creatorId: CREATOR_ID,
+                balance: '5',
+                createdAt: new Date('2026-01-01T00:00:00Z'),
+            },
+        ]);
+        mockPrisma.creatorProfile.findMany.mockResolvedValue([
+            { id: CREATOR_ID, handle: 'snap-creator' },
+        ]);
+    });
+
+    it('total_value reflects the initial price snapshot', async () => {
+        mockPrisma.creatorPriceSnapshot.findMany.mockResolvedValue([
+            { creatorId: CREATOR_ID, currentPrice: BigInt(1000) },
+        ]);
+
+        const [items, total] = await fetchWalletHoldings(WALLET_ADDRESS);
+
+        expect(total).toBe(1);
+        expect(items[0].current_price).toBe('1000');
+        expect(items[0].total_value).toBe('5000');
+    });
+
+    it('total_value and current_price update after price snapshot changes', async () => {
+        mockPrisma.creatorPriceSnapshot.findMany.mockResolvedValue([
+            { creatorId: CREATOR_ID, currentPrice: BigInt(1000) },
+        ]);
+        const [initialItems] = await fetchWalletHoldings(WALLET_ADDRESS);
+        const initialCurrentPrice = initialItems[0].current_price;
+        const initialTotalValue = initialItems[0].total_value;
+
+        expect(initialCurrentPrice).toBe('1000');
+        expect(initialTotalValue).toBe('5000');
+
+        mockPrisma.creatorPriceSnapshot.findMany.mockResolvedValue([
+            { creatorId: CREATOR_ID, currentPrice: BigInt(2500) },
+        ]);
+        const [updatedItems] = await fetchWalletHoldings(WALLET_ADDRESS);
+
+        expect(updatedItems[0].current_price).toBe('2500');
+        expect(updatedItems[0].total_value).toBe('12500');
+        expect(updatedItems[0].current_price).not.toBe(initialCurrentPrice);
+        expect(updatedItems[0].total_value).not.toBe(initialTotalValue);
+    });
+
+    it('current_price and total_value are null when no snapshot exists for the creator', async () => {
+        mockPrisma.creatorPriceSnapshot.findMany.mockResolvedValue([]);
+
+        const [items] = await fetchWalletHoldings(WALLET_ADDRESS);
+
+        expect(items[0].current_price).toBeNull();
+        expect(items[0].total_value).toBeNull();
+    });
+
+    it('total_value is computed per-holding when wallet has multiple holdings', async () => {
+        mockPrisma.keyOwnership.findMany.mockResolvedValue([
+            {
+                ownerAddress: WALLET_ADDRESS,
+                creatorId: 'creator-snap-a',
+                balance: '3',
+                createdAt: new Date('2026-01-01T00:00:00Z'),
+            },
+            {
+                ownerAddress: WALLET_ADDRESS,
+                creatorId: 'creator-snap-b',
+                balance: '2',
+                createdAt: new Date('2026-01-02T00:00:00Z'),
+            },
+        ]);
+        mockPrisma.creatorProfile.findMany.mockResolvedValue([
+            { id: 'creator-snap-a', handle: 'snap-a' },
+            { id: 'creator-snap-b', handle: 'snap-b' },
+        ]);
+        mockPrisma.creatorPriceSnapshot.findMany.mockResolvedValue([
+            { creatorId: 'creator-snap-a', currentPrice: BigInt(100) },
+            { creatorId: 'creator-snap-b', currentPrice: BigInt(200) },
+        ]);
+
+        const [items, total] = await fetchWalletHoldings(WALLET_ADDRESS);
+
+        expect(total).toBe(2);
+        expect(items[0].current_price).toBe('100');
+        expect(items[0].total_value).toBe('300');
+        expect(items[1].current_price).toBe('200');
+        expect(items[1].total_value).toBe('400');
+    });
+
+    it('total_value for each holding updates independently when snapshot changes', async () => {
+        mockPrisma.keyOwnership.findMany.mockResolvedValue([
+            {
+                ownerAddress: WALLET_ADDRESS,
+                creatorId: 'creator-snap-a',
+                balance: '3',
+                createdAt: new Date('2026-01-01T00:00:00Z'),
+            },
+            {
+                ownerAddress: WALLET_ADDRESS,
+                creatorId: 'creator-snap-b',
+                balance: '2',
+                createdAt: new Date('2026-01-02T00:00:00Z'),
+            },
+        ]);
+        mockPrisma.creatorProfile.findMany.mockResolvedValue([
+            { id: 'creator-snap-a', handle: 'snap-a' },
+            { id: 'creator-snap-b', handle: 'snap-b' },
+        ]);
+
+        mockPrisma.creatorPriceSnapshot.findMany.mockResolvedValue([
+            { creatorId: 'creator-snap-a', currentPrice: BigInt(100) },
+            { creatorId: 'creator-snap-b', currentPrice: BigInt(200) },
+        ]);
+        const [before] = await fetchWalletHoldings(WALLET_ADDRESS);
+
+        mockPrisma.creatorPriceSnapshot.findMany.mockResolvedValue([
+            { creatorId: 'creator-snap-a', currentPrice: BigInt(150) },
+            { creatorId: 'creator-snap-b', currentPrice: BigInt(200) },
+        ]);
+        const [after] = await fetchWalletHoldings(WALLET_ADDRESS);
+
+        expect(before[0].total_value).toBe('300');
+        expect(after[0].total_value).toBe('450');
+        expect(before[1].total_value).toBe(after[1].total_value);
+    });
+
+    it('returns empty items for a wallet with no holdings', async () => {
+        mockPrisma.keyOwnership.findMany.mockResolvedValue([]);
+
+        const [items, total] = await fetchWalletHoldings(WALLET_ADDRESS);
+
+        expect(total).toBe(0);
+        expect(items).toEqual([]);
+    });
+});

--- a/src/modules/wallets/wallet-holdings.service.integration.test.ts
+++ b/src/modules/wallets/wallet-holdings.service.integration.test.ts
@@ -9,7 +9,7 @@ jest.mock('../../utils/prisma.utils', () => ({
         creatorProfile: {
             findMany: jest.fn(),
         },
-        activity: {
+        creatorPriceSnapshot: {
             findMany: jest.fn(),
         },
     },
@@ -22,7 +22,7 @@ const mockPrisma = prisma as unknown as {
     creatorProfile: {
         findMany: jest.Mock;
     };
-    activity: {
+    creatorPriceSnapshot: {
         findMany: jest.Mock;
     };
 };
@@ -51,15 +51,9 @@ describe('fetchWalletHoldings ownership read model integration', () => {
             { id: 'creator-alpha', handle: 'alpha' },
             { id: 'creator-beta', handle: 'beta' },
         ]);
-        mockPrisma.activity.findMany.mockResolvedValue([
-            {
-                creatorId: 'creator-alpha',
-                payload: { price_at_trade: '10' },
-            },
-            {
-                creatorId: 'creator-beta',
-                payload: { price_at_trade: '4' },
-            },
+        mockPrisma.creatorPriceSnapshot.findMany.mockResolvedValue([
+            { creatorId: 'creator-alpha', currentPrice: BigInt(10) },
+            { creatorId: 'creator-beta', currentPrice: BigInt(4) },
         ]);
     });
 
@@ -80,14 +74,14 @@ describe('fetchWalletHoldings ownership read model integration', () => {
                 creator_handle: 'alpha',
                 key_count: '5',
                 current_price: '10',
-                total_value: null,
+                total_value: '50',
             },
             {
                 creator_id: 'creator-beta',
                 creator_handle: 'beta',
                 key_count: '2.5',
                 current_price: '4',
-                total_value: null,
+                total_value: '10',
             },
         ]);
         expect(items.map((item) => item.creator_id)).not.toContain('creator-zero');

--- a/src/modules/wallets/wallet-holdings.service.ts
+++ b/src/modules/wallets/wallet-holdings.service.ts
@@ -49,33 +49,30 @@ export async function fetchWalletHoldings(
         creatorProfiles.map((c: { id: string; handle: string }) => [c.id, c.handle])
     );
 
-    // Resolve latest price per creator from Activity in one query
-    const recentActivities = await prisma.activity.findMany({
-        where: {
-            creatorId: { in: creatorIds },
-            type: { in: ['KEY_BOUGHT', 'KEY_SOLD'] },
-        },
-        orderBy: { createdAt: 'desc' },
-        select: { creatorId: true, payload: true },
+    // Resolve latest price per creator from the price snapshot read model
+    const priceSnapshots = await prisma.creatorPriceSnapshot.findMany({
+        where: { creatorId: { in: creatorIds } },
+        select: { creatorId: true, currentPrice: true },
     });
 
-    // Build a map of creatorId → most recent price_at_trade
-    const priceMap = new Map<string, unknown>();
-    for (const act of recentActivities) {
-        if (!priceMap.has(act.creatorId as string)) {
-            const payload = (act.payload ?? {}) as Record<string, unknown>;
-            priceMap.set(act.creatorId as string, payload.price_at_trade ?? null);
-        }
+    const priceMap = new Map<string, bigint>();
+    for (const snap of priceSnapshots) {
+        priceMap.set(snap.creatorId as string, snap.currentPrice as bigint);
     }
 
     const items: HoldingEntry[] = rows.map((row: { creatorId: string; balance: unknown }) => {
-        const currentPrice = priceMap.get(row.creatorId) ?? null;
+        const rawPrice = priceMap.get(row.creatorId) ?? null;
+        const currentPrice = rawPrice !== null ? rawPrice.toString() : null;
+        const totalValue =
+            rawPrice !== null && row.balance !== null
+                ? (Number(row.balance) * Number(rawPrice)).toString()
+                : null;
         return {
             creator_id: row.creatorId,
             creator_handle: handleMap.get(row.creatorId) ?? null,
             key_count: row.balance,
             current_price: currentPrice,
-            total_value: null,
+            total_value: totalValue,
         };
     });
 


### PR DESCRIPTION
Closes #470

## Summary

- Updated `wallet-holdings.service.ts` to derive `current_price` from `creatorPriceSnapshot.currentPrice` (the dedicated price read model) instead of `Activity.payload.price_at_trade`
- Added server-side computation of `total_value` as `key_count × current_price` (previously always `null`)
- Created `wallet-holdings-price-snapshot.integration.test.ts` with 6 focused tests covering the snapshot-driven recalculation

## Test implementation overview

**New file:** `src/modules/wallets/wallet-holdings-price-snapshot.integration.test.ts`

Tests use Jest mocks (no database required), following the established pattern in this codebase:

| Test | What it covers |
|---|---|
| `total_value reflects the initial price snapshot` | Baseline: price × balance = correct total_value |
| `total_value and current_price update after price snapshot changes` | Core acceptance criterion: both fields change when snapshot is updated |
| `current_price and total_value are null when no snapshot exists` | Null-safety when creator has no price snapshot |
| `total_value is computed per-holding when wallet has multiple holdings` | Correct per-holding computation with two creators |
| `total_value for each holding updates independently` | Only the creator whose snapshot changed has a new total_value |
| `returns empty items for a wallet with no holdings` | Zero-holdings edge case |

**Updated:** `wallet-holdings.service.integration.test.ts` — switched mock from `activity.findMany` to `creatorPriceSnapshot.findMany` and updated `total_value` expectations from `null` to computed values.

## Test execution results

```
Test Suites: 2 passed, 2 total
Tests:       7 passed, 7 total
```

## Acceptance criteria coverage

- [x] `total_value` recalculates correctly after price snapshot update
- [x] `current_price` on each holding reflects the latest snapshot
- [x] Integration test passes (7/7)
- [x] `npm run lint` passes without errors (eslint clean on changed files)
- [x] Build errors are pre-existing (unrelated to Prisma client generation) — confirmed identical errors on `main` before any changes