### PR TITLE
feat: typed query-param helper, request entry logger, and creator isolation tests

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,7 @@ import { apiVersionMiddleware } from './middlewares/api-version.middleware';
 import { schemaVersionMiddleware } from './middlewares/schema-version.middleware';
 import { requestLoggerMiddleware } from './middlewares/request-logger.middleware';
 import { requestContextMiddleware } from './middlewares/request-context.middleware';
+import { requestEntryLoggerMiddleware } from './middlewares/request-entry-logger.middleware';
 import { bodyParseErrorMiddleware } from './middlewares/body-parse-error.middleware';
 import { envConfig } from './config';
 
@@ -27,6 +28,7 @@ app.use(requestContextMiddleware);
 app.use(apiVersionMiddleware);
 app.use(schemaVersionMiddleware);
 app.use(requestIdMiddleware);
+app.use(requestEntryLoggerMiddleware);
 app.use(corsMiddleware());
 app.use(helmet());
 app.use(express.json({ limit: '10mb' }));

--- a/src/middlewares/request-entry-logger.middleware.test.ts
+++ b/src/middlewares/request-entry-logger.middleware.test.ts
@@ -1,0 +1,116 @@
+import { requestEntryLoggerMiddleware } from './request-entry-logger.middleware';
+import { logger } from '../utils/logger.utils';
+
+jest.mock('../utils/logger.utils', () => ({
+  logger: { info: jest.fn() },
+}));
+
+function makeReq(overrides: Record<string, unknown> = {}): any {
+  return {
+    method: 'GET',
+    path: '/api/v1/health',
+    requestId: 'test-request-id',
+    ip: '203.0.113.42',
+    headers: { 'user-agent': 'jest-test-agent' },
+    socket: { remoteAddress: '203.0.113.42' },
+    ...overrides,
+  };
+}
+
+function makeRes(): any {
+  return {};
+}
+
+describe('requestEntryLoggerMiddleware', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('emits a log before calling next', () => {
+    const next = jest.fn();
+    requestEntryLoggerMiddleware(makeReq(), makeRes(), next);
+    expect((logger.info as jest.Mock).mock.calls.length).toBe(1);
+    expect(next).toHaveBeenCalled();
+    const callOrder = (logger.info as jest.Mock).mock.invocationCallOrder[0];
+    const nextOrder = (next as jest.Mock).mock.invocationCallOrder[0];
+    expect(callOrder).toBeLessThan(nextOrder);
+  });
+
+  it('includes all five required fields', () => {
+    requestEntryLoggerMiddleware(makeReq(), makeRes(), jest.fn());
+    const log = (logger.info as jest.Mock).mock.calls[0][0];
+    expect(log).toHaveProperty('request_id');
+    expect(log).toHaveProperty('method');
+    expect(log).toHaveProperty('path');
+    expect(log).toHaveProperty('ip');
+    expect(log).toHaveProperty('user_agent');
+  });
+
+  it('uses req.requestId as request_id when present', () => {
+    requestEntryLoggerMiddleware(makeReq({ requestId: 'my-trace-id' }), makeRes(), jest.fn());
+    const log = (logger.info as jest.Mock).mock.calls[0][0];
+    expect(log.request_id).toBe('my-trace-id');
+  });
+
+  it('generates a UUID when requestId is absent', () => {
+    const req = makeReq();
+    delete req.requestId;
+    requestEntryLoggerMiddleware(req, makeRes(), jest.fn());
+    const log = (logger.info as jest.Mock).mock.calls[0][0];
+    expect(log.request_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+  });
+
+  it('masks IP to /24 subnet (zeroes last octet)', () => {
+    requestEntryLoggerMiddleware(makeReq({ ip: '203.0.113.42' }), makeRes(), jest.fn());
+    const log = (logger.info as jest.Mock).mock.calls[0][0];
+    expect(log.ip).toBe('203.0.113.0');
+  });
+
+  it('masks different /24 subnets correctly', () => {
+    requestEntryLoggerMiddleware(makeReq({ ip: '192.168.1.99' }), makeRes(), jest.fn());
+    const log = (logger.info as jest.Mock).mock.calls[0][0];
+    expect(log.ip).toBe('192.168.1.0');
+  });
+
+  it('does not include request body', () => {
+    requestEntryLoggerMiddleware(
+      makeReq({ body: { password: 'secret' } }),
+      makeRes(),
+      jest.fn()
+    );
+    const log = (logger.info as jest.Mock).mock.calls[0][0];
+    expect(log).not.toHaveProperty('body');
+  });
+
+  it('does not include query string', () => {
+    requestEntryLoggerMiddleware(
+      makeReq({ query: { secret_token: 'abc' } }),
+      makeRes(),
+      jest.fn()
+    );
+    const log = (logger.info as jest.Mock).mock.calls[0][0];
+    expect(log).not.toHaveProperty('query');
+  });
+
+  it('logs the correct method', () => {
+    requestEntryLoggerMiddleware(makeReq({ method: 'POST' }), makeRes(), jest.fn());
+    const log = (logger.info as jest.Mock).mock.calls[0][0];
+    expect(log.method).toBe('POST');
+  });
+
+  it('logs the correct path', () => {
+    requestEntryLoggerMiddleware(makeReq({ path: '/api/v1/creators' }), makeRes(), jest.fn());
+    const log = (logger.info as jest.Mock).mock.calls[0][0];
+    expect(log.path).toBe('/api/v1/creators');
+  });
+
+  it('logs the user-agent header', () => {
+    requestEntryLoggerMiddleware(
+      makeReq({ headers: { 'user-agent': 'Mozilla/5.0' } }),
+      makeRes(),
+      jest.fn()
+    );
+    const log = (logger.info as jest.Mock).mock.calls[0][0];
+    expect(log.user_agent).toBe('Mozilla/5.0');
+  });
+});

--- a/src/middlewares/request-entry-logger.middleware.ts
+++ b/src/middlewares/request-entry-logger.middleware.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
+import { logger } from '../utils/logger.utils';
+
+function maskIpToSubnet24(ip: string | undefined): string | undefined {
+  if (!ip) return undefined;
+  const parts = ip.split('.');
+  if (parts.length === 4) {
+    return `${parts[0]}.${parts[1]}.${parts[2]}.0`;
+  }
+  return ip;
+}
+
+export const requestEntryLoggerMiddleware = (
+  req: Request,
+  _res: Response,
+  next: NextFunction
+): void => {
+  const requestId = (req as any).requestId ?? crypto.randomUUID();
+
+  logger.info({
+    type: 'request_entry',
+    request_id: requestId,
+    method: req.method,
+    path: req.path,
+    ip: maskIpToSubnet24((req as any).ip ?? req.socket?.remoteAddress),
+    user_agent: req.headers['user-agent'],
+  });
+
+  next();
+};

--- a/src/modules/wallets/wallet-activity-creator-filter.integration.test.ts
+++ b/src/modules/wallets/wallet-activity-creator-filter.integration.test.ts
@@ -1,0 +1,191 @@
+// Integration test: wallet activity creator_id filter (#476)
+//
+// Verifies that GET /wallets/:address/activity with creator_id returns only
+// trades for the specified creator, excluding trades for all other creators,
+// and that combining creator_id + type filters works correctly.
+
+import { fetchWalletActivity } from './wallet-activity.service';
+import { prisma } from '../../utils/prisma.utils';
+
+jest.mock('../../utils/prisma.utils', () => ({
+  prisma: {
+    activity: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+    creatorProfile: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+const mockPrisma = prisma as unknown as {
+  activity: { findMany: jest.Mock; count: jest.Mock };
+  creatorProfile: { findMany: jest.Mock };
+};
+
+const WALLET_ADDRESS = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA';
+const CREATOR_A = 'creator-filter-a';
+const CREATOR_B = 'creator-filter-b';
+
+const seededActivities = [
+  {
+    type: 'KEY_BOUGHT',
+    actor: WALLET_ADDRESS,
+    creatorId: CREATOR_A,
+    payload: { amount: '5', price_at_trade: '20', fee_paid: '0.5', ledger_sequence: 201 },
+    createdAt: new Date('2026-06-10T00:00:00Z'),
+  },
+  {
+    type: 'KEY_SOLD',
+    actor: WALLET_ADDRESS,
+    creatorId: CREATOR_A,
+    payload: { amount: '2', price_at_trade: '25', fee_paid: '0.4', ledger_sequence: 202 },
+    createdAt: new Date('2026-06-11T00:00:00Z'),
+  },
+  {
+    type: 'KEY_BOUGHT',
+    actor: WALLET_ADDRESS,
+    creatorId: CREATOR_B,
+    payload: { amount: '3', price_at_trade: '15', fee_paid: '0.3', ledger_sequence: 203 },
+    createdAt: new Date('2026-06-12T00:00:00Z'),
+  },
+  {
+    type: 'KEY_SOLD',
+    actor: WALLET_ADDRESS,
+    creatorId: CREATOR_B,
+    payload: { amount: '1', price_at_trade: '18', fee_paid: '0.2', ledger_sequence: 204 },
+    createdAt: new Date('2026-06-13T00:00:00Z'),
+  },
+];
+
+function applyWhere(where: {
+  actor: string;
+  creatorId?: string;
+  type?: string | { in: string[] };
+}) {
+  return seededActivities.filter((a) => {
+    if (a.actor !== where.actor) return false;
+    if (where.creatorId && a.creatorId !== where.creatorId) return false;
+    if (where.type) {
+      if (typeof where.type === 'string') {
+        if (a.type !== where.type) return false;
+      } else if (where.type.in && !where.type.in.includes(a.type)) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPrisma.activity.findMany.mockImplementation(({ where }) =>
+    Promise.resolve(applyWhere(where))
+  );
+  mockPrisma.activity.count.mockImplementation(({ where }) =>
+    Promise.resolve(applyWhere(where).length)
+  );
+  mockPrisma.creatorProfile.findMany.mockResolvedValue([
+    { id: CREATOR_A, handle: 'handle-a' },
+    { id: CREATOR_B, handle: 'handle-b' },
+  ]);
+});
+
+describe('fetchWalletActivity — creator_id filter (#476)', () => {
+  it('returns only trades for creator A when creator_id=CREATOR_A', async () => {
+    const [items, total] = await fetchWalletActivity(WALLET_ADDRESS, {
+      creator_id: CREATOR_A,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(total).toBe(2);
+    expect(items).toHaveLength(2);
+    expect(items.every((i) => i.creator_id === CREATOR_A)).toBe(true);
+  });
+
+  it('excludes all trades from creator B when filtering by creator A', async () => {
+    const [items] = await fetchWalletActivity(WALLET_ADDRESS, {
+      creator_id: CREATOR_A,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(items.some((i) => i.creator_id === CREATOR_B)).toBe(false);
+  });
+
+  it('returns only trades for creator B when creator_id=CREATOR_B', async () => {
+    const [items, total] = await fetchWalletActivity(WALLET_ADDRESS, {
+      creator_id: CREATOR_B,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(total).toBe(2);
+    expect(items).toHaveLength(2);
+    expect(items.every((i) => i.creator_id === CREATOR_B)).toBe(true);
+  });
+
+  it('excludes all trades from creator A when filtering by creator B', async () => {
+    const [items] = await fetchWalletActivity(WALLET_ADDRESS, {
+      creator_id: CREATOR_B,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(items.some((i) => i.creator_id === CREATOR_A)).toBe(false);
+  });
+
+  it('combines creator_id and type=buy filters correctly', async () => {
+    const [items, total] = await fetchWalletActivity(WALLET_ADDRESS, {
+      creator_id: CREATOR_A,
+      type: 'buy',
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(total).toBe(1);
+    expect(items).toHaveLength(1);
+    expect(items[0].creator_id).toBe(CREATOR_A);
+    expect(items[0].type).toBe('buy');
+  });
+
+  it('combines creator_id and type=sell filters correctly', async () => {
+    const [items, total] = await fetchWalletActivity(WALLET_ADDRESS, {
+      creator_id: CREATOR_B,
+      type: 'sell',
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(total).toBe(1);
+    expect(items).toHaveLength(1);
+    expect(items[0].creator_id).toBe(CREATOR_B);
+    expect(items[0].type).toBe('sell');
+  });
+
+  it('passes creatorId in the where clause when creator_id is provided', async () => {
+    await fetchWalletActivity(WALLET_ADDRESS, {
+      creator_id: CREATOR_A,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(mockPrisma.activity.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ creatorId: CREATOR_A }),
+      })
+    );
+  });
+
+  it('returns all trades when no creator_id filter is applied', async () => {
+    const [items, total] = await fetchWalletActivity(WALLET_ADDRESS, {
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(total).toBe(4);
+    expect(items).toHaveLength(4);
+  });
+});

--- a/src/modules/webhooks/webhook.integration.test.ts
+++ b/src/modules/webhooks/webhook.integration.test.ts
@@ -9,6 +9,32 @@ const keypair = Keypair.random();
 const walletAddress = keypair.publicKey();
 const testUserId = 'webhook-test-user-id';
 const creatorId = 'webhook-test-creator-id';
+
+const keypairA = Keypair.random();
+const walletAddressA = keypairA.publicKey();
+const userIdA = 'webhook-isolation-user-a';
+const creatorIdA = 'webhook-isolation-creator-a';
+
+const keypairB = Keypair.random();
+const walletAddressB = keypairB.publicKey();
+const userIdB = 'webhook-isolation-user-b';
+const creatorIdB = 'webhook-isolation-creator-b';
+
+function signMessageFor(keypair: Keypair, method: string, path: string, cId: string, timestamp: string): string {
+  const payload = `${method.toUpperCase()}:${path}:${cId}:${timestamp}`;
+  const hash = createHash('sha256').update(payload, 'utf8').digest();
+  return keypair.sign(hash).toString('base64');
+}
+
+function authHeadersFor(kp: Keypair, method: string, path: string, cId: string) {
+  const timestamp = Date.now().toString();
+  const signature = signMessageFor(kp, method, path, cId, timestamp);
+  return {
+    'x-wallet-address': kp.publicKey(),
+    'x-signature': signature,
+    'x-timestamp': timestamp,
+  };
+}
 function signMessage(method: string, path: string, creatorId: string, timestamp: string): string {
   const payload = `${method.toUpperCase()}:${path}:${creatorId}:${timestamp}`;
   const hash = createHash('sha256').update(payload, 'utf8').digest();
@@ -307,4 +333,92 @@ describe('webhook dispatch', () => {
     await prisma.webhookEvent.deleteMany({ where: { webhookId: failingWebhook.id } });
     await prisma.webhook.delete({ where: { id: failingWebhook.id } });
   }, 30000);
+});
+
+describe('GET /api/v1/creators/:id/webhooks — isolation between creators (#474)', () => {
+  beforeAll(async () => {
+    for (const [userId, email, walletAddr, cId, handle, displayName] of [
+      [userIdA, 'webhook-isolation-a@example.com', walletAddressA, creatorIdA, 'isolation-creator-a', 'Isolation Creator A'],
+      [userIdB, 'webhook-isolation-b@example.com', walletAddressB, creatorIdB, 'isolation-creator-b', 'Isolation Creator B'],
+    ] as const) {
+      await prisma.user.create({
+        data: { id: userId, email, passwordHash: 'dummy-hash', firstName: 'Isolation', lastName: 'Test' },
+      });
+      await prisma.stellarWallet.create({ data: { address: walletAddr, userId } });
+      await prisma.creatorProfile.create({ data: { id: cId, userId, handle, displayName } });
+    }
+
+    const pathA = `/api/v1/creators/${creatorIdA}/webhooks`;
+    const pathB = `/api/v1/creators/${creatorIdB}/webhooks`;
+
+    await supertest(app)
+      .post(pathA)
+      .set(authHeadersFor(keypairA, 'POST', pathA, creatorIdA))
+      .send({ callback_url: 'https://example.com/hook-a1', events: ['buy'] });
+
+    await supertest(app)
+      .post(pathA)
+      .set(authHeadersFor(keypairA, 'POST', pathA, creatorIdA))
+      .send({ callback_url: 'https://example.com/hook-a2', events: ['sell'] });
+
+    await supertest(app)
+      .post(pathB)
+      .set(authHeadersFor(keypairB, 'POST', pathB, creatorIdB))
+      .send({ callback_url: 'https://example.com/hook-b1', events: ['buy', 'sell'] });
+  });
+
+  afterAll(async () => {
+    await prisma.webhook.deleteMany({ where: { creatorId: creatorIdA } });
+    await prisma.webhook.deleteMany({ where: { creatorId: creatorIdB } });
+    for (const [cId, walletAddr, userId] of [
+      [creatorIdA, walletAddressA, userIdA],
+      [creatorIdB, walletAddressB, userIdB],
+    ] as const) {
+      await prisma.creatorProfile.delete({ where: { id: cId } }).catch(() => {});
+      await prisma.stellarWallet.delete({ where: { address: walletAddr } }).catch(() => {});
+      await prisma.user.delete({ where: { id: userId } }).catch(() => {});
+    }
+  });
+
+  it("creator A's webhook list contains no webhooks from creator B", async () => {
+    const pathA = `/api/v1/creators/${creatorIdA}/webhooks`;
+    const res = await supertest(app)
+      .get(pathA)
+      .set(authHeadersFor(keypairA, 'GET', pathA, creatorIdA));
+
+    expect(res.status).toBe(200);
+    const webhooks = res.body.data as Array<{ creatorId?: string; callbackUrl: string }>;
+    expect(webhooks.every((w) => !w.callbackUrl.includes('hook-b'))).toBe(true);
+  });
+
+  it("creator B's webhook list contains no webhooks from creator A", async () => {
+    const pathB = `/api/v1/creators/${creatorIdB}/webhooks`;
+    const res = await supertest(app)
+      .get(pathB)
+      .set(authHeadersFor(keypairB, 'GET', pathB, creatorIdB));
+
+    expect(res.status).toBe(200);
+    const webhooks = res.body.data as Array<{ callbackUrl: string }>;
+    expect(webhooks.every((w) => !w.callbackUrl.includes('hook-a'))).toBe(true);
+  });
+
+  it("count for creator A matches the number of webhooks registered for A", async () => {
+    const pathA = `/api/v1/creators/${creatorIdA}/webhooks`;
+    const res = await supertest(app)
+      .get(pathA)
+      .set(authHeadersFor(keypairA, 'GET', pathA, creatorIdA));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+  });
+
+  it("count for creator B matches the number of webhooks registered for B", async () => {
+    const pathB = `/api/v1/creators/${creatorIdB}/webhooks`;
+    const res = await supertest(app)
+      .get(pathB)
+      .set(authHeadersFor(keypairB, 'GET', pathB, creatorIdB));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+  });
 });

--- a/src/utils/query-param.utils.test.ts
+++ b/src/utils/query-param.utils.test.ts
@@ -1,0 +1,103 @@
+import { readQueryParam } from './query-param.utils';
+
+describe('readQueryParam — string type', () => {
+  it('returns the string value when present', () => {
+    expect(readQueryParam({ q: 'hello' }, 'q', 'string', 'default')).toBe('hello');
+  });
+
+  it('returns defaultValue when param is missing', () => {
+    expect(readQueryParam({}, 'q', 'string', 'default')).toBe('default');
+  });
+
+  it('returns defaultValue when param is empty string', () => {
+    expect(readQueryParam({ q: '' }, 'q', 'string', 'default')).toBe('default');
+  });
+
+  it('returns defaultValue when param is null', () => {
+    expect(readQueryParam({ q: null }, 'q', 'string', 'fallback')).toBe('fallback');
+  });
+
+  it('uses first element of array value', () => {
+    expect(readQueryParam({ q: ['first', 'second'] }, 'q', 'string', 'x')).toBe('first');
+  });
+
+  it('returns undefined defaultValue when absent and default is undefined', () => {
+    expect(readQueryParam({}, 'q', 'string', undefined)).toBeUndefined();
+  });
+});
+
+describe('readQueryParam — number type', () => {
+  it('returns parsed integer when param is a valid non-negative number string', () => {
+    expect(readQueryParam({ n: '42' }, 'n', 'number', 0)).toBe(42);
+  });
+
+  it('returns 0 as a valid value', () => {
+    expect(readQueryParam({ n: '0' }, 'n', 'number', 99)).toBe(0);
+  });
+
+  it('returns defaultValue when param is missing', () => {
+    expect(readQueryParam({}, 'n', 'number', 10)).toBe(10);
+  });
+
+  it('returns defaultValue when param is NaN', () => {
+    expect(readQueryParam({ n: 'abc' }, 'n', 'number', 5)).toBe(5);
+  });
+
+  it('returns defaultValue when param is negative', () => {
+    expect(readQueryParam({ n: '-1' }, 'n', 'number', 7)).toBe(7);
+  });
+
+  it('returns defaultValue when param is a float string (not an integer)', () => {
+    expect(readQueryParam({ n: '3.14' }, 'n', 'number', 0)).toBe(3);
+  });
+
+  it('returns defaultValue when param is empty string', () => {
+    expect(readQueryParam({ n: '' }, 'n', 'number', 99)).toBe(99);
+  });
+
+  it('uses first element of array value', () => {
+    expect(readQueryParam({ n: ['7', '8'] }, 'n', 'number', 0)).toBe(7);
+  });
+});
+
+describe('readQueryParam — boolean type', () => {
+  it('returns true for "true"', () => {
+    expect(readQueryParam({ b: 'true' }, 'b', 'boolean', false)).toBe(true);
+  });
+
+  it('returns false for "false"', () => {
+    expect(readQueryParam({ b: 'false' }, 'b', 'boolean', true)).toBe(false);
+  });
+
+  it('is case-insensitive — accepts "True"', () => {
+    expect(readQueryParam({ b: 'True' }, 'b', 'boolean', false)).toBe(true);
+  });
+
+  it('is case-insensitive — accepts "FALSE"', () => {
+    expect(readQueryParam({ b: 'FALSE' }, 'b', 'boolean', true)).toBe(false);
+  });
+
+  it('returns defaultValue when param is missing', () => {
+    expect(readQueryParam({}, 'b', 'boolean', true)).toBe(true);
+  });
+
+  it('returns defaultValue for invalid string "yes"', () => {
+    expect(readQueryParam({ b: 'yes' }, 'b', 'boolean', false)).toBe(false);
+  });
+
+  it('returns defaultValue for invalid string "1"', () => {
+    expect(readQueryParam({ b: '1' }, 'b', 'boolean', false)).toBe(false);
+  });
+
+  it('returns defaultValue for invalid string "0"', () => {
+    expect(readQueryParam({ b: '0' }, 'b', 'boolean', true)).toBe(true);
+  });
+
+  it('returns defaultValue when param is empty string', () => {
+    expect(readQueryParam({ b: '' }, 'b', 'boolean', true)).toBe(true);
+  });
+
+  it('uses first element of array value', () => {
+    expect(readQueryParam({ b: ['true', 'false'] }, 'b', 'boolean', false)).toBe(true);
+  });
+});

--- a/src/utils/query-param.utils.ts
+++ b/src/utils/query-param.utils.ts
@@ -1,0 +1,54 @@
+type QueryParamType = 'string' | 'number' | 'boolean';
+
+type QueryParamReturn<T extends QueryParamType, D> = D extends undefined
+  ? T extends 'string'
+    ? string | undefined
+    : T extends 'number'
+    ? number | undefined
+    : boolean | undefined
+  : T extends 'string'
+  ? string
+  : T extends 'number'
+  ? number
+  : boolean;
+
+/**
+ * Safely reads a typed value from an Express query-param map.
+ *
+ * - 'string': returns the raw value as-is, or defaultValue when missing.
+ * - 'number': parses as integer; returns defaultValue when missing, NaN, or negative.
+ * - 'boolean': accepts only 'true'/'false' strings (case-insensitive);
+ *              returns defaultValue for anything else or when missing.
+ */
+export function readQueryParam<T extends QueryParamType, D extends QueryParamReturn<T, undefined> | undefined>(
+  params: Record<string, unknown>,
+  key: string,
+  type: T,
+  defaultValue: D
+): QueryParamReturn<T, D> {
+  const raw = params[key];
+
+  if (raw === undefined || raw === null || raw === '') {
+    return defaultValue as QueryParamReturn<T, D>;
+  }
+
+  const value = Array.isArray(raw) ? raw[0] : String(raw);
+
+  if (type === 'string') {
+    return value as QueryParamReturn<T, D>;
+  }
+
+  if (type === 'number') {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isNaN(parsed) || parsed < 0) {
+      return defaultValue as QueryParamReturn<T, D>;
+    }
+    return parsed as QueryParamReturn<T, D>;
+  }
+
+  // boolean
+  const lower = value.toLowerCase();
+  if (lower === 'true') return true as QueryParamReturn<T, D>;
+  if (lower === 'false') return false as QueryParamReturn<T, D>;
+  return defaultValue as QueryParamReturn<T, D>;
+}


### PR DESCRIPTION
## Summary

This PR resolves four assigned issues across two areas: new utilities/middleware and integration test coverage for existing endpoints. It adds a typed query-param reader helper, a structured request entry log middleware, and two new integration test suites that verify creator isolation on the webhook list and wallet activity feed endpoints.

closes #473
closes #474
closes #475
closes #476

## Changes

- **#473 — `readQueryParam` typed query-param helper**: Adds `src/utils/query-param.utils.ts` with a `readQueryParam(params, key, type, defaultValue)` function that safely reads and coerces Express query string values into `string`, `number`, or `boolean`. Numbers return the default on NaN or negative values; booleans accept only `'true'`/`'false'` (case-insensitive). Unit tests cover all three types for the present, missing, and invalid cases.

- **#475 — Structured request entry log**: Adds `src/middlewares/request-entry-logger.middleware.ts` that emits a `pino` info log at the start of every incoming request before the handler runs. Fields logged: `request_id` (existing trace ID or a generated UUID), `method`, `path`, `ip` (masked to `/24` subnet — last octet zeroed), `user_agent`. Request body and query string are deliberately excluded to avoid leaking sensitive data. Middleware is mounted in `app.ts` immediately after `requestIdMiddleware`. Unit tests verify all five fields, IP masking, UUID fallback, and body/query absence.

- **#474 — Webhook list cross-creator isolation**: Extends `webhook.integration.test.ts` with a new `describe` block that provisions two isolated creators (A and B) each with their own Stellar keypairs and sets of webhooks. Asserts that querying creator A returns zero of creator B's webhooks (and vice versa) and that per-creator counts exactly match the number registered. All seeded data is cleaned up in `afterAll`.

- **#476 — Wallet activity `creator_id` filter isolation**: Adds `wallet-activity-creator-filter.integration.test.ts` which seeds trade events for two different creators against the same wallet address and asserts: creator A filter excludes all of creator B's trades, creator B filter excludes all of creator A's trades, combined `creator_id` + `type` filters work correctly, and the `creatorId` field is present in the Prisma `where` clause.

## Test plan

- `readQueryParam`: unit tests in `query-param.utils.test.ts` cover all branches (present/missing/invalid for each type).
- Request entry logger: unit tests in `request-entry-logger.middleware.test.ts` cover field presence, IP masking, UUID fallback, and body/query exclusion.
- Webhook isolation: integration test in `webhook.integration.test.ts` (new describe block) using real Supertest + app instance with DB-backed fixtures.
- Wallet activity filter: integration test in `wallet-activity-creator-filter.integration.test.ts` using mocked Prisma (matching the existing pattern in this module).

---

Not built/tested locally against a live database; relying on CI for the DB-backed integration tests. TypeScript types were matched by hand — no local `tsc` run.