### PR TITLE
feat: held-since helper, indexer trade log, and price alert integration tests

### DIFF
--- a/src/modules/alerts/__tests__/alert-price-crossing.integration.test.ts
+++ b/src/modules/alerts/__tests__/alert-price-crossing.integration.test.ts
@@ -1,0 +1,217 @@
+// Integration tests for price alert firing and post-delivery cleanup (#464, #472)
+//
+// #464: Verifies that the registered callback receives a POST with the correct
+//       payload when the creator key price crosses the registered threshold.
+// #472: Verifies that the alert record is deleted (set inactive) after a
+//       successful delivery, and that a second crossing does not retrigger.
+
+import { evaluatePriceAlertsForMovement } from '../alert.service';
+import { prisma } from '../../../utils/prisma.utils';
+
+jest.mock('../../../utils/prisma.utils', () => ({
+  prisma: {
+    priceAlert: {
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+const mockPrisma = prisma as unknown as {
+  priceAlert: {
+    findMany: jest.Mock;
+    update: jest.Mock;
+  };
+};
+
+const CREATOR_ID = 'creator-alert-test';
+const WALLET_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const CALLBACK_URL = 'https://hooks.example.com/price-alert';
+
+const BASE_ALERT = {
+  id: 'alert-fire-test',
+  creatorId: CREATOR_ID,
+  walletAddress: WALLET_ADDRESS,
+  targetPrice: 100,
+  direction: 'above' as const,
+  callbackUrl: CALLBACK_URL,
+  isActive: true,
+  triggeredAt: null,
+  createdAt: new Date('2026-06-01T00:00:00Z'),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+});
+
+describe('price alert fires when price crosses threshold (#464)', () => {
+  it('calls the callback URL when price crosses above the target', async () => {
+    mockPrisma.priceAlert.findMany.mockResolvedValue([BASE_ALERT]);
+    mockPrisma.priceAlert.update.mockResolvedValue({});
+
+    await evaluatePriceAlertsForMovement({
+      creatorId: CREATOR_ID,
+      previousPrice: 90,
+      currentPrice: 110,
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      CALLBACK_URL,
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('sends the correct payload to the callback', async () => {
+    mockPrisma.priceAlert.findMany.mockResolvedValue([BASE_ALERT]);
+    mockPrisma.priceAlert.update.mockResolvedValue({});
+
+    await evaluatePriceAlertsForMovement({
+      creatorId: CREATOR_ID,
+      previousPrice: 90,
+      currentPrice: 110,
+    });
+
+    const callArgs = (global.fetch as jest.Mock).mock.calls[0];
+    const body = JSON.parse(callArgs[1].body);
+
+    expect(body.creator_id).toBe(CREATOR_ID);
+    expect(body.target_price).toBe(100);
+    expect(body.current_price).toBe(110);
+    expect(body.direction).toBe('above');
+    expect(body.event_type).toBe('price_alert');
+  });
+
+  it('calls the callback when price crosses below the target', async () => {
+    const belowAlert = { ...BASE_ALERT, id: 'alert-below', direction: 'below' as const, targetPrice: 80 };
+    mockPrisma.priceAlert.findMany.mockResolvedValue([belowAlert]);
+    mockPrisma.priceAlert.update.mockResolvedValue({});
+
+    await evaluatePriceAlertsForMovement({
+      creatorId: CREATOR_ID,
+      previousPrice: 90,
+      currentPrice: 70,
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.direction).toBe('below');
+    expect(body.current_price).toBe(70);
+  });
+
+  it('does not call the callback when price does not cross the threshold', async () => {
+    mockPrisma.priceAlert.findMany.mockResolvedValue([BASE_ALERT]);
+
+    await evaluatePriceAlertsForMovement({
+      creatorId: CREATOR_ID,
+      previousPrice: 90,
+      currentPrice: 95,
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not call the callback when price crosses in the wrong direction', async () => {
+    // alert is 'above' but price dropped
+    mockPrisma.priceAlert.findMany.mockResolvedValue([BASE_ALERT]);
+
+    await evaluatePriceAlertsForMovement({
+      creatorId: CREATOR_ID,
+      previousPrice: 110,
+      currentPrice: 90,
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('includes alert_id in the callback payload', async () => {
+    mockPrisma.priceAlert.findMany.mockResolvedValue([BASE_ALERT]);
+    mockPrisma.priceAlert.update.mockResolvedValue({});
+
+    await evaluatePriceAlertsForMovement({
+      creatorId: CREATOR_ID,
+      previousPrice: 90,
+      currentPrice: 110,
+    });
+
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.alert_id).toBe(BASE_ALERT.id);
+  });
+});
+
+describe('price alert deleted after successful webhook delivery (#472)', () => {
+  it('marks the alert inactive after successful delivery', async () => {
+    mockPrisma.priceAlert.findMany.mockResolvedValue([BASE_ALERT]);
+    mockPrisma.priceAlert.update.mockResolvedValue({});
+
+    await evaluatePriceAlertsForMovement({
+      creatorId: CREATOR_ID,
+      previousPrice: 90,
+      currentPrice: 110,
+    });
+
+    expect(mockPrisma.priceAlert.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: BASE_ALERT.id },
+        data: expect.objectContaining({ isActive: false }),
+      })
+    );
+  });
+
+  it('sets triggeredAt after successful delivery', async () => {
+    mockPrisma.priceAlert.findMany.mockResolvedValue([BASE_ALERT]);
+    mockPrisma.priceAlert.update.mockResolvedValue({});
+
+    await evaluatePriceAlertsForMovement({
+      creatorId: CREATOR_ID,
+      previousPrice: 90,
+      currentPrice: 110,
+    });
+
+    const updateCall = mockPrisma.priceAlert.update.mock.calls[0][0];
+    expect(updateCall.data.triggeredAt).toBeInstanceOf(Date);
+  });
+
+  it('does not re-trigger when the alert is already inactive (second crossing)', async () => {
+    // Second call: alert is not returned because isActive: false filters it out
+    mockPrisma.priceAlert.findMany.mockResolvedValue([]);
+
+    await evaluatePriceAlertsForMovement({
+      creatorId: CREATOR_ID,
+      previousPrice: 90,
+      currentPrice: 120,
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockPrisma.priceAlert.update).not.toHaveBeenCalled();
+  });
+
+  it('does not mark alert inactive when the callback fails', async () => {
+    mockPrisma.priceAlert.findMany.mockResolvedValue([BASE_ALERT]);
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(
+      evaluatePriceAlertsForMovement({
+        creatorId: CREATOR_ID,
+        previousPrice: 90,
+        currentPrice: 110,
+      })
+    ).rejects.toThrow();
+
+    expect(mockPrisma.priceAlert.update).not.toHaveBeenCalled();
+  });
+
+  it('update is called exactly once per alert per movement', async () => {
+    mockPrisma.priceAlert.findMany.mockResolvedValue([BASE_ALERT]);
+    mockPrisma.priceAlert.update.mockResolvedValue({});
+
+    await evaluatePriceAlertsForMovement({
+      creatorId: CREATOR_ID,
+      previousPrice: 90,
+      currentPrice: 110,
+    });
+
+    expect(mockPrisma.priceAlert.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/held-since.utils.test.ts
+++ b/src/utils/held-since.utils.test.ts
@@ -1,0 +1,73 @@
+import { getHeldSince, TradeEvent } from './held-since.utils';
+
+const WALLET = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const CREATOR = 'creator-abc';
+
+function makeBuy(timestamp: Date, wallet = WALLET, creator = CREATOR): TradeEvent {
+  return { walletAddress: wallet, creatorId: creator, type: 'buy', timestamp };
+}
+
+function makeSell(timestamp: Date, wallet = WALLET, creator = CREATOR): TradeEvent {
+  return { walletAddress: wallet, creatorId: creator, type: 'sell', timestamp };
+}
+
+describe('getHeldSince', () => {
+  it('returns null when the event list is empty', () => {
+    expect(getHeldSince(WALLET, CREATOR, [])).toBeNull();
+  });
+
+  it('returns null when there are no buy events for the wallet/creator pair', () => {
+    const events: TradeEvent[] = [makeSell(new Date('2026-01-01'))];
+    expect(getHeldSince(WALLET, CREATOR, events)).toBeNull();
+  });
+
+  it('returns the timestamp of a single buy event', () => {
+    const ts = new Date('2026-03-15T10:00:00Z');
+    expect(getHeldSince(WALLET, CREATOR, [makeBuy(ts)])).toEqual(ts);
+  });
+
+  it('returns the earliest timestamp when multiple buy events exist', () => {
+    const early = new Date('2026-01-01T00:00:00Z');
+    const late = new Date('2026-06-01T00:00:00Z');
+    const events = [makeBuy(late), makeBuy(early)];
+    expect(getHeldSince(WALLET, CREATOR, events)).toEqual(early);
+  });
+
+  it('ignores sell events when finding the earliest buy', () => {
+    const sellTs = new Date('2025-12-01T00:00:00Z');
+    const buyTs = new Date('2026-02-01T00:00:00Z');
+    const events = [makeSell(sellTs), makeBuy(buyTs)];
+    expect(getHeldSince(WALLET, CREATOR, events)).toEqual(buyTs);
+  });
+
+  it('filters by walletAddress — ignores buys from other wallets', () => {
+    const otherWallet = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA';
+    const events = [makeBuy(new Date('2026-01-01'), otherWallet)];
+    expect(getHeldSince(WALLET, CREATOR, events)).toBeNull();
+  });
+
+  it('filters by creatorId — ignores buys for other creators', () => {
+    const events = [makeBuy(new Date('2026-01-01'), WALLET, 'creator-other')];
+    expect(getHeldSince(WALLET, CREATOR, events)).toBeNull();
+  });
+
+  it('returns the correct earliest among many buys for the same wallet/creator', () => {
+    const ts1 = new Date('2026-03-01T00:00:00Z');
+    const ts2 = new Date('2026-01-01T00:00:00Z');
+    const ts3 = new Date('2026-05-01T00:00:00Z');
+    const events = [makeBuy(ts1), makeBuy(ts2), makeBuy(ts3)];
+    expect(getHeldSince(WALLET, CREATOR, events)).toEqual(ts2);
+  });
+
+  it('handles mixed wallets and creators — returns earliest for the matching pair only', () => {
+    const matchTs = new Date('2026-06-01T00:00:00Z');
+    const otherWalletTs = new Date('2026-01-01T00:00:00Z');
+    const otherCreatorTs = new Date('2026-02-01T00:00:00Z');
+    const events = [
+      makeBuy(matchTs),
+      makeBuy(otherWalletTs, 'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCD'),
+      makeBuy(otherCreatorTs, WALLET, 'creator-other'),
+    ];
+    expect(getHeldSince(WALLET, CREATOR, events)).toEqual(matchTs);
+  });
+});

--- a/src/utils/held-since.utils.ts
+++ b/src/utils/held-since.utils.ts
@@ -1,0 +1,29 @@
+export interface TradeEvent {
+  walletAddress: string;
+  creatorId: string;
+  type: 'buy' | 'sell';
+  timestamp: Date;
+}
+
+/**
+ * Returns the timestamp of the earliest buy event for the given wallet and
+ * creator, or null if no matching buy event exists.
+ */
+export function getHeldSince(
+  walletAddress: string,
+  creatorId: string,
+  tradeEvents: TradeEvent[]
+): Date | null {
+  const buyTimestamps = tradeEvents
+    .filter(
+      (e) =>
+        e.type === 'buy' &&
+        e.walletAddress === walletAddress &&
+        e.creatorId === creatorId
+    )
+    .map((e) => e.timestamp.getTime());
+
+  if (buyTimestamps.length === 0) return null;
+
+  return new Date(Math.min(...buyTimestamps));
+}

--- a/src/utils/indexer-trade-event-logger.utils.test.ts
+++ b/src/utils/indexer-trade-event-logger.utils.test.ts
@@ -1,0 +1,95 @@
+import { logIndexerTradeEvent, IndexerTradeEventLogFields } from './indexer-trade-event-logger.utils';
+import { logger } from './logger.utils';
+
+jest.mock('./logger.utils', () => ({
+  logger: { info: jest.fn() },
+}));
+
+const infoMock = logger.info as jest.Mock;
+
+const BASE_FIELDS: IndexerTradeEventLogFields = {
+  event_type: 'buy',
+  creator_id: 'creator-xyz',
+  ledger_sequence: 12345,
+  actor_address: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  amount: '5',
+  processed_at: new Date('2026-06-26T10:00:00Z'),
+};
+
+describe('logIndexerTradeEvent', () => {
+  beforeEach(() => infoMock.mockClear());
+
+  it('emits exactly one structured info log', () => {
+    logIndexerTradeEvent(BASE_FIELDS);
+    expect(infoMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes all required fields in the log object', () => {
+    logIndexerTradeEvent(BASE_FIELDS);
+    const [logObj] = infoMock.mock.calls[0];
+    expect(logObj).toHaveProperty('event_type');
+    expect(logObj).toHaveProperty('creator_id');
+    expect(logObj).toHaveProperty('ledger_sequence');
+    expect(logObj).toHaveProperty('actor_address');
+    expect(logObj).toHaveProperty('amount');
+    expect(logObj).toHaveProperty('processed_at');
+  });
+
+  it('logs event_type correctly for a buy event', () => {
+    logIndexerTradeEvent({ ...BASE_FIELDS, event_type: 'buy' });
+    expect(infoMock.mock.calls[0][0].event_type).toBe('buy');
+  });
+
+  it('logs event_type correctly for a sell event', () => {
+    logIndexerTradeEvent({ ...BASE_FIELDS, event_type: 'sell' });
+    expect(infoMock.mock.calls[0][0].event_type).toBe('sell');
+  });
+
+  it('logs creator_id correctly', () => {
+    logIndexerTradeEvent({ ...BASE_FIELDS, creator_id: 'creator-abc' });
+    expect(infoMock.mock.calls[0][0].creator_id).toBe('creator-abc');
+  });
+
+  it('logs ledger_sequence correctly', () => {
+    logIndexerTradeEvent({ ...BASE_FIELDS, ledger_sequence: 99999 });
+    expect(infoMock.mock.calls[0][0].ledger_sequence).toBe(99999);
+  });
+
+  it('masks actor_address to first 4 and last 4 characters', () => {
+    logIndexerTradeEvent(BASE_FIELDS);
+    const addr = infoMock.mock.calls[0][0].actor_address as string;
+    expect(addr).toMatch(/^GAAA\.\.\.AAAA$/);
+  });
+
+  it('masks short addresses without truncating', () => {
+    logIndexerTradeEvent({ ...BASE_FIELDS, actor_address: 'ABCDEFGH' });
+    expect(infoMock.mock.calls[0][0].actor_address).toBe('ABCDEFGH');
+  });
+
+  it('masks a different address correctly (first 4 + last 4)', () => {
+    logIndexerTradeEvent({ ...BASE_FIELDS, actor_address: 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA' });
+    const addr = infoMock.mock.calls[0][0].actor_address as string;
+    expect(addr.startsWith('GBBB')).toBe(true);
+    expect(addr.endsWith('BBBA')).toBe(true);
+    expect(addr).toContain('...');
+  });
+
+  it('does not log the full actor_address in clear text', () => {
+    const fullAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    logIndexerTradeEvent({ ...BASE_FIELDS, actor_address: fullAddress });
+    const addr = infoMock.mock.calls[0][0].actor_address as string;
+    expect(addr).not.toBe(fullAddress);
+    expect(addr.length).toBeLessThan(fullAddress.length);
+  });
+
+  it('logs processed_at as an ISO string', () => {
+    const ts = new Date('2026-06-26T10:00:00Z');
+    logIndexerTradeEvent({ ...BASE_FIELDS, processed_at: ts });
+    expect(infoMock.mock.calls[0][0].processed_at).toBe('2026-06-26T10:00:00.000Z');
+  });
+
+  it('logs amount correctly', () => {
+    logIndexerTradeEvent({ ...BASE_FIELDS, amount: '42' });
+    expect(infoMock.mock.calls[0][0].amount).toBe('42');
+  });
+});

--- a/src/utils/indexer-trade-event-logger.utils.ts
+++ b/src/utils/indexer-trade-event-logger.utils.ts
@@ -1,0 +1,34 @@
+import { logger } from './logger.utils';
+
+export interface IndexerTradeEventLogFields {
+  event_type: 'buy' | 'sell';
+  creator_id: string;
+  ledger_sequence: number;
+  actor_address: string;
+  amount: string;
+  processed_at: Date;
+}
+
+function maskActorAddress(address: string): string {
+  if (address.length <= 8) return address;
+  return `${address.slice(0, 4)}...${address.slice(-4)}`;
+}
+
+/**
+ * Emits a structured info log after a trade event is successfully written to
+ * the database. Must only be called after the write succeeds — not on failure.
+ */
+export function logIndexerTradeEvent(fields: IndexerTradeEventLogFields): void {
+  logger.info(
+    {
+      type: 'indexer_trade_processed',
+      event_type: fields.event_type,
+      creator_id: fields.creator_id,
+      ledger_sequence: fields.ledger_sequence,
+      actor_address: maskActorAddress(fields.actor_address),
+      amount: fields.amount,
+      processed_at: fields.processed_at.toISOString(),
+    },
+    'Indexer trade event processed'
+  );
+}


### PR DESCRIPTION
## Summary

This PR resolves four assigned issues: a new utility helper for computing `held_since` timestamps, a structured log utility for indexed trade events, and two integration test suites covering price alert firing and post-delivery cleanup.

closes #463
closes #464
closes #465
closes #472

## Changes

- **#463 — `getHeldSince` helper**: Adds `src/utils/held-since.utils.ts` with `getHeldSince(walletAddress, creatorId, tradeEvents)` which finds the earliest buy event matching both the wallet and creator from a list of trade events. Returns `null` when no match exists. Unit tests cover: single buy, multiple buys (earliest returned), sell-only list, empty list, wrong wallet, wrong creator, and mixed scenarios.

- **#465 — Indexer trade event structured log**: Adds `src/utils/indexer-trade-event-logger.utils.ts` with `logIndexerTradeEvent` that emits a pino info log after each trade event is successfully written to the database. Fields: `event_type`, `creator_id`, `ledger_sequence`, `actor_address` (masked to first 4 + `...` + last 4 chars to avoid leaking full addresses), `amount`, `processed_at` (ISO string). The function is designed to be called only after a successful DB write. Unit tests verify all fields, both event types, address masking behavior, and `processed_at` ISO formatting.

- **#464 — Price alert fires on threshold crossing**: Adds `alert-price-crossing.integration.test.ts` (in `__tests__/`) asserting that `evaluatePriceAlertsForMovement` calls the registered callback URL with a POST containing the correct payload (`creator_id`, `target_price`, `current_price`, `direction`, `alert_id`, `event_type`) when price crosses the threshold. Covers above/below crossings, non-crossing movements, and wrong-direction scenarios.

- **#472 — Price alert deleted after successful delivery**: In the same test file, asserts that after a successful callback delivery the alert is marked `isActive: false` with a `triggeredAt` timestamp. Verifies a second price crossing does not re-trigger the deactivated alert, and that the alert is NOT marked inactive when the callback returns a non-OK status.

## Test plan

- `getHeldSince`: 9 unit tests covering all branches.
- `logIndexerTradeEvent`: 11 unit tests covering all fields, masking, and formatting.
- Price alert integration: 11 integration tests (5 for #464 firing, 5 for #472 cleanup, 1 shared scenario) using mocked Prisma and `global.fetch`, consistent with the existing `alert-price-movement.integration.test.ts` pattern.

---

Not built/tested locally against a live database; relying on CI. TypeScript types matched by hand.