### PR TITLE
feat: add structured logs for webhook delivery retries with backoff d…

### DIFF
--- a/src/modules/webhooks/webhook.service.test.ts
+++ b/src/modules/webhooks/webhook.service.test.ts
@@ -1,6 +1,7 @@
 import { prisma } from '../../utils/prisma.utils';
 import { envConfig } from '../../config';
 import * as webhookService from './webhook.service';
+import { logger } from '../../utils/logger.utils';
 
 jest.mock('../../utils/prisma.utils', () => ({
   prisma: {
@@ -272,6 +273,28 @@ describe('dispatchWebhookEvent', () => {
       expect.objectContaining({
         data: expect.objectContaining({ status: 'FAILED' }),
       })
+    );
+
+    expect(logger.warn).toHaveBeenCalledTimes(envConfig.WEBHOOK_RETRY_MAX_ATTEMPTS - 1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webhook_id: 'wh-1',
+        creator_id: 'creator-1',
+        attempt_number: 2,
+        backoff_delay_ms: 2000,
+        last_error_code: 'Network error',
+      }),
+      'Webhook delivery failed, retrying'
+    );
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webhook_id: 'wh-1',
+        creator_id: 'creator-1',
+        attempt_number: envConfig.WEBHOOK_RETRY_MAX_ATTEMPTS,
+        last_error_code: 'Network error',
+      }),
+      'Webhook delivery exhausted all retries, flagged as failing'
     );
   });
 });

--- a/src/modules/webhooks/webhook.service.ts
+++ b/src/modules/webhooks/webhook.service.ts
@@ -151,7 +151,13 @@ async function attemptDelivery(
     if (attempt < maxAttempts) {
       const delay = Math.pow(2, attempt) * 1000;
       logger.warn(
-        { webhookId, attempt, maxAttempts, nextRetryMs: delay, error: errMsg },
+        {
+          webhook_id: webhookId,
+          creator_id: payload.creator_id,
+          attempt_number: attempt + 1,
+          backoff_delay_ms: delay,
+          last_error_code: errMsg,
+        },
         'Webhook delivery failed, retrying'
       );
       await new Promise((resolve) => setTimeout(resolve, delay));
@@ -169,7 +175,12 @@ async function attemptDelivery(
     });
 
     logger.error(
-      { webhookId, attempt, maxAttempts, error: errMsg },
+      {
+        webhook_id: webhookId,
+        creator_id: payload.creator_id,
+        attempt_number: attempt,
+        last_error_code: errMsg,
+      },
       'Webhook delivery exhausted all retries, flagged as failing'
     );
   }


### PR DESCRIPTION
Closes #469

## Summary

- Emits a structured `warn` log before each delivery retry containing `webhook_id`, `creator_id`, `attempt_number` (starting at 2), `backoff_delay_ms`, and `last_error_code`.
- Emits a final `error` log when the webhook exhausts all delivery attempts and is flagged as failing.
- Added comprehensive unit tests to ensure log statements are called correctly during the backoff sequence.

## Testing

- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] `pnpm exec prisma generate` when schema or generated types changed

## Checklist

- [x] Linked issue or backlog item
- [x] No secrets or live credentials added
- [ ] Docs updated if setup or env changed
- [x] Change is scoped to one problem
