### PR TITLE
feat: add structured logging for alert registration and deletion

### DIFF
--- a/src/modules/alerts/__tests__/alert.service.test.ts
+++ b/src/modules/alerts/__tests__/alert.service.test.ts
@@ -5,6 +5,7 @@
 
 import { createAlert, listAlerts, deleteAlert } from '../alert.service';
 import { prisma } from '../../../utils/prisma.utils';
+import { logger } from '../../../utils/logger.utils';
 
 jest.mock('../../../utils/prisma.utils', () => ({
     prisma: {
@@ -15,6 +16,10 @@ jest.mock('../../../utils/prisma.utils', () => ({
             delete: jest.fn(),
         },
     },
+}));
+
+jest.mock('../../../utils/logger.utils', () => ({
+    logger: { info: jest.fn() },
 }));
 
 const mockedPrisma = prisma as jest.Mocked<typeof prisma>;
@@ -59,6 +64,19 @@ describe('createAlert', () => {
             },
         });
         expect(result).toEqual(DB_ALERT);
+
+        expect(logger.info).toHaveBeenCalledWith(
+            expect.objectContaining({
+                alert_id: DB_ALERT.id,
+                creator_id: DB_ALERT.creatorId,
+                direction: DB_ALERT.direction,
+                target_price: DB_ALERT.targetPrice,
+                registered_at: DB_ALERT.createdAt,
+                wallet_address: 'GAAA***AAAA',
+            }),
+            'Price alert registered'
+        );
+        expect((logger.info as jest.Mock).mock.calls[0][0]).not.toHaveProperty('callback_url');
     });
 
     it('creates a below-direction alert', async () => {
@@ -114,6 +132,17 @@ describe('deleteAlert', () => {
             where: { id: 'alert-1' },
         });
         expect(result).toEqual({ id: 'alert-1' });
+
+        expect(logger.info).toHaveBeenCalledWith(
+            expect.objectContaining({
+                alert_id: DB_ALERT.id,
+                creator_id: DB_ALERT.creatorId,
+                cancelled_at: expect.any(Date),
+                wallet_address: 'GAAA***AAAA',
+            }),
+            'Price alert cancelled'
+        );
+        expect((logger.info as jest.Mock).mock.calls[0][0]).not.toHaveProperty('callback_url');
     });
 
     it('returns null when the alert is not found', async () => {

--- a/src/modules/alerts/alert.service.ts
+++ b/src/modules/alerts/alert.service.ts
@@ -13,7 +13,7 @@ export type PriceMovement = {
  * Creates a new price alert for a wallet address watching a creator's key price.
  */
 export async function createAlert(input: CreateAlertInput) {
-    return await prisma.priceAlert.create({
+    const alert = await prisma.priceAlert.create({
         data: {
             creatorId: input.creator_id,
             walletAddress: input.wallet_address,
@@ -22,6 +22,20 @@ export async function createAlert(input: CreateAlertInput) {
             callbackUrl: input.callback_url,
         },
     });
+
+    logger.info(
+        {
+            alert_id: alert.id,
+            creator_id: alert.creatorId,
+            direction: alert.direction,
+            target_price: toNumber(alert.targetPrice),
+            registered_at: alert.createdAt,
+            wallet_address: maskWalletAddress(alert.walletAddress),
+        },
+        'Price alert registered'
+    );
+
+    return alert;
 }
 
 /**
@@ -51,11 +65,27 @@ export async function deleteAlert(
     }
 
     await prisma.priceAlert.delete({ where: { id } });
+
+    logger.info(
+        {
+            alert_id: existing.id,
+            creator_id: existing.creatorId,
+            cancelled_at: new Date(),
+            wallet_address: maskWalletAddress(existing.walletAddress),
+        },
+        'Price alert cancelled'
+    );
+
     return { id };
 }
 
 function toNumber(value: number | string | { toString(): string }): number {
     return typeof value === 'number' ? value : Number(value.toString());
+}
+
+function maskWalletAddress(address: string): string {
+    if (address.length <= 8) return address;
+    return `${address.slice(0, 4)}***${address.slice(-4)}`;
 }
 
 function maskCallbackUrl(callbackUrl: string): string {


### PR DESCRIPTION
# Closes #505

   ### Summary
   Adds structured observability logs when price alerts are successfully registered or manually cancelled. This allows monitoring alert activity without querying the database and provides debugging context for unexpectedly fired alerts.

   ### What Changed
   - Added `logger.info` to `createAlert` emitting `alert_id`, `creator_id`, `direction`, `target_price`, and `registered_at`.
   - Added `logger.info` to `deleteAlert` emitting `alert_id`, `creator_id`, and `cancelled_at`.
   - Created a `maskWalletAddress` helper inside the alert service to log wallet addresses safely.
   - Updated `alert.service.test.ts` to mock `logger.info` and assert payload structures.

   ### Key Design Decisions
   - Included the masked `wallet_address` explicitly in the log payloads. Because alerts operate on behalf of a wallet, auditing *who* acted is highly logical and provides useful context without leaking full addresses.
   - Used the existing `toNumber` helper inside the service to safely serialise Prisma `Decimal` instances for the logger.

   ### Acceptance Criteria
   - [x] Registration log emitted with all five fields
   - [x] Cancellation log emitted on manual delete
   - [x] Wallet address masked (first 4 and last 4 characters), callback URL absent from all logs

   ### Test Output & Coverage
   - 7/7 tests passed in `alert.service.test.ts`
   - Tests cover both successful logs, ensuring masked data correctness and the explicit absence of `callback_url`.

   ### Security Note
   PII is completely isolated. `callback_url` is omitted entirely from these logs, and the `wallet_address` is strictly masked to its first and last 4 characters (`GAAA***AAAA`) before passing to the logger payload.

   ### Follow-ups
   - Consider standardising wallet address masking across modules (currently there's a slightly different `maskAddress` in `ownership.service.ts` and `wallet.utils.ts`).