### PR TITLE
test: cover empty webhook list for creators with no registered webhooks (#551)

### DIFF
--- a/src/modules/webhooks/webhook.integration.test.ts
+++ b/src/modules/webhooks/webhook.integration.test.ts
@@ -475,3 +475,67 @@ describe('GET /api/v1/creators/:id/webhooks — isolation between creators (#474
     expect(res.body.data).toHaveLength(1);
   });
 });
+
+describe('GET /api/v1/creators/:id/webhooks — empty list for creator with no webhooks (#551)', () => {
+  // Use a dedicated keypair + creator that has no webhooks registered.
+  // The creator ID is a positive-integer-format string to satisfy
+  // parseCreatorId in webhook-signature.middleware.ts.
+  const emptyKeypair = Keypair.random();
+  const emptyWalletAddress = emptyKeypair.publicKey();
+  const emptyUserId = 'webhook-empty-user-551';
+  const emptyCreatorId = '551001';
+  const emptyHandle = 'webhook-empty-creator-551';
+  const emptyListPath = `/api/v1/creators/${emptyCreatorId}/webhooks`;
+
+  beforeAll(async () => {
+    await prisma.user.create({
+      data: {
+        id: emptyUserId,
+        email: 'webhook-empty-551@example.com',
+        passwordHash: 'dummy-hash',
+        firstName: 'Empty',
+        lastName: 'Webhooks',
+      },
+    });
+
+    await prisma.stellarWallet.create({
+      data: {
+        address: emptyWalletAddress,
+        userId: emptyUserId,
+      },
+    });
+
+    await prisma.creatorProfile.create({
+      data: {
+        id: emptyCreatorId,
+        userId: emptyUserId,
+        handle: emptyHandle,
+        displayName: 'Empty Webhooks Creator',
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.webhook.deleteMany({ where: { creatorId: emptyCreatorId } });
+    await prisma.creatorProfile.delete({ where: { id: emptyCreatorId } }).catch(() => {});
+    await prisma.stellarWallet.delete({ where: { address: emptyWalletAddress } }).catch(() => {});
+    await prisma.user.delete({ where: { id: emptyUserId } }).catch(() => {});
+  });
+
+  it('returns 200 with an empty array when the creator has not registered any webhooks (#551)', async () => {
+    // Sanity-check: ensure no webhooks are persisted in the DB for this creator.
+    const dbCount = await prisma.webhook.count({
+      where: { creatorId: emptyCreatorId },
+    });
+    expect(dbCount).toBe(0);
+
+    const res = await supertest(app)
+      .get(emptyListPath)
+      .set(authHeadersFor(emptyKeypair, 'GET', emptyListPath, emptyCreatorId));
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data).toEqual([]);
+  });
+});


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2><p>Closes #551</p><p>This PR adds an integration test to verify that <code inline="">GET /api/v1/creators/:id/webhooks</code> returns <strong><code inline="">200 OK</code></strong> with an <strong>empty array (<code inline="">[]</code>)</strong> when a creator exists but has not registered any webhooks.</p><p>The current implementation is already correct. The <code inline="">listWebhooksHandler</code> in <code inline="">src/modules/webhooks/webhook.controllers.ts</code> delegates to <code inline="">webhookService.listWebhooks</code>, which returns an empty array when no matching webhook records are found. This change adds automated test coverage to ensure that behavior remains consistent over time.</p><h2>Scope</h2><p>The new integration test:</p><ul><li><p>Creates a valid creator (User → StellarWallet → CreatorProfile) without registering any webhooks.</p></li><li><p>Sends an authenticated request to <code inline="">GET /api/v1/creators/:id/webhooks</code> using wallet-signed headers generated from the creator's Stellar keypair.</p></li><li><p>Verifies that the endpoint returns:</p><ul><li><p><strong>HTTP 200 OK</strong></p></li><li><p><code inline="">success: true</code></p></li><li><p><code inline="">data: []</code></p></li></ul></li></ul><h2>Files Changed</h2>
File | Description
-- | --
src/modules/webhooks/webhook.integration.test.ts | Adds a new integration test covering the "creator with no webhooks" scenario.

<h2>Verification</h2><p>The following checks were executed locally:</p><pre><code class="language-bash">docker compose up -d postgres

DATABASE_URL=postgresql://postgres:postgres@localhost:5432/accesslayer \
pnpm exec prisma db push --force-reset --skip-generate

pnpm exec prisma generate

DATABASE_URL=postgresql://postgres:postgres@localhost:5432/accesslayer \
pnpm jest src/modules/webhooks/webhook.integration.test.ts -t "#551" --runInBand

pnpm exec tsc --noEmit
</code></pre><p>All commands completed successfully. The new <code inline="">#551</code> integration test passed, and <code inline="">tsc --noEmit</code> exited without errors.</p><h2>Risk Assessment</h2><p><strong>Low risk.</strong></p><p>This is a test-only change. No production code or application behavior has been modified.</p><h2>Out of Scope</h2><p>This PR does not address existing integration tests that use non-numeric creator IDs (for example, <code inline="">"webhook-test-creator-id"</code>), which may fail the current <code inline="">parseCreatorId</code> validation. Those pre-existing issues are unrelated to this change and will be handled separately.</p></body></html><!--EndFragment-->
</body>
</html>