### PR TITLE
test(webhooks): add integration test for webhook retry on 500 response (#578)

### DIFF
--- a/src/modules/webhooks/webhook.integration.test.ts
+++ b/src/modules/webhooks/webhook.integration.test.ts
@@ -1,3 +1,4 @@
+import http from 'http';
 import supertest from 'supertest';
 import app from '../../app';
 import { prisma } from '../../utils/prisma.utils';
@@ -537,5 +538,98 @@ describe('GET /api/v1/creators/:id/webhooks — empty list for creator with no w
     expect(res.body.success).toBe(true);
     expect(Array.isArray(res.body.data)).toBe(true);
     expect(res.body.data).toEqual([]);
+  });
+});
+
+describe('webhook retry on 500 response (#578)', () => {
+  let mockServer: http.Server;
+  let mockServerUrl: string;
+  let requestTimestamps: number[];
+  let secondRequestResolve: () => void;
+
+  beforeAll((done) => {
+    let requestCount = 0;
+    requestTimestamps = [];
+
+    mockServer = http.createServer((_req, res) => {
+      requestTimestamps.push(Date.now());
+      requestCount++;
+
+      if (requestCount === 1) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Internal Server Error' }));
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+        secondRequestResolve();
+      }
+    });
+
+    mockServer.listen(0, '127.0.0.1', () => {
+      const address = mockServer.address() as any;
+      mockServerUrl = `http://127.0.0.1:${address.port}/webhook`;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    mockServer.close(done);
+  });
+
+  it('retries delivery after a 500 response and succeeds on the second attempt', async () => {
+    const secondRequestPromise = new Promise<void>((resolve) => {
+      secondRequestResolve = resolve;
+    });
+
+    const webhook = await prisma.webhook.create({
+      data: {
+        id: 'webhook-retry-500-test',
+        creatorId,
+        callbackUrl: mockServerUrl,
+        events: { set: ['BUY'] },
+      },
+    });
+
+    const { dispatchWebhookEvent } = await import('./webhook.service');
+
+    await dispatchWebhookEvent({
+      type: 'buy',
+      creatorId,
+      buyerOrSellerAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+      amount: '100',
+      price: '10.5',
+      feePaid: '0.5',
+      timestamp: new Date().toISOString(),
+    });
+
+    // Wait for the retry (second request after backoff)
+    await secondRequestPromise;
+
+    // Allow time for DB writes after the second response
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // Assert callback was called twice
+    expect(requestTimestamps.length).toBe(2);
+
+    // Assert second call happened after the configured backoff delay
+    const backoffDelay = requestTimestamps[1] - requestTimestamps[0];
+    expect(backoffDelay).toBeGreaterThanOrEqual(2000);
+
+    // Assert webhook event was delivered successfully after retry
+    const events = await prisma.webhookEvent.findMany({
+      where: { webhookId: webhook.id },
+    });
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0].status).toBe('DELIVERED');
+    expect(events[0].retryCount).toBe(2);
+
+    // Assert webhook is NOT marked as failing after successful retry
+    const updatedWebhook = await prisma.webhook.findUnique({
+      where: { id: webhook.id },
+    });
+    expect(updatedWebhook?.isFailing).toBe(false);
+
+    await prisma.webhookEvent.deleteMany({ where: { webhookId: webhook.id } });
+    await prisma.webhook.delete({ where: { id: webhook.id } });
   });
 });


### PR DESCRIPTION
# Closes #578

## Summary

Adds an integration test to verify that the webhook delivery system correctly retries after receiving a **500 Internal Server Error** from the callback URL, rather than immediately marking the webhook as failing.

## Test Approach

1. **Mock server**: A local HTTP server is started that returns `500` on the first request and `200` on all subsequent requests. Request timestamps are recorded.
2. **Webhook registration**: A webhook is created via Prisma pointing to the mock server URL.
3. **Event dispatch**: `dispatchWebhookEvent` is called with a buy trade event, triggering delivery to the mock server.
4. **Retry verification**:
   - The first attempt receives a `500` → the service applies exponential backoff (`Math.pow(2, 1) * 1000 = 2000ms`)
   - The second attempt receives a `200` → the event is marked `DELIVERED`
5. **Assertions**:
   - Callback was called exactly twice (first fail, then success)
   - Time between calls ≥ 2000ms (correct backoff delay)
   - Webhook event status is `DELIVERED` with `retryCount: 2`
   - Webhook is **not** marked as `isFailing: true` (only flagged after all retries are exhausted)

## Acceptance Criteria Met

- [x] Callback called twice: once failing, once succeeding
- [x] Webhook not marked as failed after successful retry
- [x] Retry fires after the configured backoff delay

## Files Changed

- `src/modules/webhooks/webhook.integration.test.ts` — Added the new test block with mock HTTP server and assertions