### PR TITLE
test: add integration test for holdings total_value multi snapshot up…

### DIFF
--- a/src/modules/wallets/__tests__/wallet-holdings-multiple-snapshots.integration.test.ts
+++ b/src/modules/wallets/__tests__/wallet-holdings-multiple-snapshots.integration.test.ts
@@ -1,0 +1,103 @@
+import supertest from 'supertest';
+import app from '../../../app';
+import { prisma } from '../../../utils/prisma.utils';
+
+describe('GET /api/v1/wallets/:address/holdings - multiple price snapshot updates', () => {
+  const WALLET_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+  const USER_ID = 'wallet-multi-snap-user';
+  const CREATOR_ID = 'wallet-multi-snap-creator';
+  const HOLDING_BALANCE = 5.0; // 5 keys held
+
+  beforeAll(async () => {
+    // Clean up database tables to avoid tests leaking into each other
+    await prisma.keyOwnership.deleteMany({});
+    await prisma.creatorPriceSnapshot.deleteMany({});
+    await prisma.creatorProfile.deleteMany({});
+    await prisma.user.deleteMany({});
+
+    // Seed a User
+    await prisma.user.create({
+      data: {
+        id: USER_ID,
+        email: 'wallet-multi-snap@example.test',
+        passwordHash: 'dummy-hash',
+        firstName: 'Wallet',
+        lastName: 'Multi Snap',
+      },
+    });
+
+    // Seed a Creator
+    await prisma.creatorProfile.create({
+      data: {
+        id: CREATOR_ID,
+        userId: USER_ID,
+        handle: 'wallet_multi_snap_creator',
+        displayName: 'Wallet Multi Snap Creator',
+      },
+    });
+
+    // Seed KeyOwnership
+    await prisma.keyOwnership.create({
+      data: {
+        ownerAddress: WALLET_ADDRESS,
+        creatorId: CREATOR_ID,
+        balance: HOLDING_BALANCE,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    // Clean up seeded database tables
+    await prisma.keyOwnership.deleteMany({});
+    await prisma.creatorPriceSnapshot.deleteMany({});
+    await prisma.creatorProfile.deleteMany({});
+    await prisma.user.deleteMany({});
+  });
+
+  it('should reflect the correct total_value after multiple price snapshot updates', async () => {
+    // First snapshot update
+    await prisma.creatorPriceSnapshot.upsert({
+      where: { creatorId: CREATOR_ID },
+      update: { currentPrice: 100n },
+      create: { creatorId: CREATOR_ID, currentPrice: 100n },
+    });
+
+    let res = await supertest(app).get(`/api/v1/wallets/${WALLET_ADDRESS}/holdings`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    let items = res.body.data.items;
+    expect(items).toHaveLength(1);
+    expect(items[0].current_price).toBe('100');
+    expect(items[0].total_value).toBe('500');
+
+    // Second snapshot update
+    await prisma.creatorPriceSnapshot.upsert({
+      where: { creatorId: CREATOR_ID },
+      update: { currentPrice: 250n },
+      create: { creatorId: CREATOR_ID, currentPrice: 250n },
+    });
+
+    res = await supertest(app).get(`/api/v1/wallets/${WALLET_ADDRESS}/holdings`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    items = res.body.data.items;
+    expect(items).toHaveLength(1);
+    expect(items[0].current_price).toBe('250');
+    expect(items[0].total_value).toBe('1250');
+
+    // Third snapshot update
+    await prisma.creatorPriceSnapshot.upsert({
+      where: { creatorId: CREATOR_ID },
+      update: { currentPrice: 300n },
+      create: { creatorId: CREATOR_ID, currentPrice: 300n },
+    });
+
+    res = await supertest(app).get(`/api/v1/wallets/${WALLET_ADDRESS}/holdings`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    items = res.body.data.items;
+    expect(items).toHaveLength(1);
+    expect(items[0].current_price).toBe('300');
+    expect(items[0].total_value).toBe('1500');
+  });
+});


### PR DESCRIPTION
#closes #584 
# Add integration test for holdings endpoint returning correct total_value after multiple price snapshot updates

Closes #584

## Description
This PR introduces a new integration test for the `/api/v1/wallets/:address/holdings` endpoint to ensure the `total_value` calculation accurately tracks dynamic price updates.

### Summary
The holdings endpoint computes the total value of held keys dynamically from the latest price snapshot. This integration test confirms the value is recalculated correctly when a creator's price snapshot is updated multiple times, guaranteeing that the most recent snapshot value is always utilized.

### Scope Covered
- Seeds a user wallet holding keys for one specific creator (`5` keys held).
- Updates the creator's price snapshot three sequential times to distinct values (`100`, `250`, `300`).
- Hits the `/holdings` API endpoint after each snapshot update.
- Asserts that `total_value` consistently aligns with the most recent snapshot (`500`, `1250`, `1500`).

## Acceptance Criteria Met
- [x] `total_value` uses the latest snapshot after each update
- [x] Previous snapshot values do not bleed into the response
- [x] Field is accurate across all three snapshot updates

## Testing Instructions
1. Run local dependencies (database):
   ```bash
   pnpm db:up
   ```
2. Execute the integration test suite:
   ```bash
   pnpm test src/modules/wallets/__tests__/wallet-holdings-multiple-snapshots.integration.test.ts
   ```
#closes 