### PR TITLE
#646 Add unit tests for keyset cursor pagination helper confirming no records skipped between pages

### DIFF
--- a/src/utils/test/pagination.utils.test.ts
+++ b/src/utils/test/pagination.utils.test.ts
@@ -63,6 +63,134 @@ describe('paginateQuery', () => {
    });
 });
 
+describe('paginateQuery - multi-page coverage with 15 trade records', () => {
+   const TOTAL = 15;
+   const PAGE_SIZE = 5;
+
+   interface TradeRecord {
+      id: number;
+      ledger: number;
+      tx_hash: string;
+   }
+
+   const allTrades: TradeRecord[] = Array.from({ length: TOTAL }, (_, i) => ({
+      id: i + 1,
+      ledger: 500_000 + i,
+      tx_hash: `0x${String(i + 1).padStart(64, '0')}`,
+   }));
+
+   const mockQueryFn = jest
+      .fn()
+      .mockImplementation(
+         async ({
+            take,
+            skip,
+            cursor,
+         }: {
+            take: number;
+            skip?: number;
+            cursor?: number;
+         }): Promise<TradeRecord[]> => {
+            let startIndex = 0;
+            if (cursor !== undefined) {
+               startIndex = allTrades.findIndex(r => r.id === cursor);
+               if (startIndex === -1) return [];
+            }
+            if (skip) startIndex += skip;
+            return allTrades.slice(startIndex, startIndex + take);
+         }
+      );
+
+   afterEach(() => {
+      jest.clearAllMocks();
+   });
+
+   it('covers all 15 records across three pages with no duplicates', async () => {
+      const allSeen: TradeRecord[] = [];
+
+      const page1 = await paginateQuery<TradeRecord>(mockQueryFn, {
+         limit: PAGE_SIZE,
+      });
+      expect(page1.data).toHaveLength(PAGE_SIZE);
+      expect(page1.hasMore).toBe(true);
+      expect(page1.nextCursor).toBeDefined();
+      allSeen.push(...page1.data);
+
+      const page2 = await paginateQuery<TradeRecord>(mockQueryFn, {
+         cursor: page1.nextCursor,
+         limit: PAGE_SIZE,
+      });
+      expect(page2.data).toHaveLength(PAGE_SIZE);
+      expect(page2.hasMore).toBe(true);
+      expect(page2.nextCursor).toBeDefined();
+      allSeen.push(...page2.data);
+
+      const page3 = await paginateQuery<TradeRecord>(mockQueryFn, {
+         cursor: page2.nextCursor,
+         limit: PAGE_SIZE,
+      });
+      expect(page3.data).toHaveLength(PAGE_SIZE);
+      expect(page3.hasMore).toBe(false);
+      expect(page3.nextCursor).toBeUndefined();
+      allSeen.push(...page3.data);
+
+      expect(allSeen).toHaveLength(TOTAL);
+      expect(new Set(allSeen.map(r => r.id)).size).toBe(TOTAL);
+   });
+
+   it('each page cursor correctly advances to the next set', async () => {
+      const page1 = await paginateQuery<TradeRecord>(mockQueryFn, {
+         limit: PAGE_SIZE,
+      });
+      expect(page1.data.map(r => r.id)).toEqual([1, 2, 3, 4, 5]);
+      expect(page1.nextCursor).toBe(5);
+
+      const page2 = await paginateQuery<TradeRecord>(mockQueryFn, {
+         cursor: page1.nextCursor,
+         limit: PAGE_SIZE,
+      });
+      expect(page2.data.map(r => r.id)).toEqual([6, 7, 8, 9, 10]);
+      expect(page2.nextCursor).toBe(10);
+
+      const page3 = await paginateQuery<TradeRecord>(mockQueryFn, {
+         cursor: page2.nextCursor,
+         limit: PAGE_SIZE,
+      });
+      expect(page3.data.map(r => r.id)).toEqual([11, 12, 13, 14, 15]);
+      expect(page3.hasMore).toBe(false);
+      expect(page3.nextCursor).toBeUndefined();
+   });
+
+   it('final page returns hasMore false', async () => {
+      const page2 = await paginateQuery<TradeRecord>(mockQueryFn, {
+         cursor: 10,
+         limit: PAGE_SIZE,
+      });
+      expect(page2.hasMore).toBe(false);
+      expect(page2.nextCursor).toBeUndefined();
+   });
+
+   it('no records are skipped between pages', async () => {
+      const page1 = await paginateQuery<TradeRecord>(mockQueryFn, {
+         limit: PAGE_SIZE,
+      });
+      const page2 = await paginateQuery<TradeRecord>(mockQueryFn, {
+         cursor: page1.nextCursor,
+         limit: PAGE_SIZE,
+      });
+
+      const allIds = [
+         ...page1.data.map(r => r.id),
+         ...page2.data.map(r => r.id),
+      ];
+      const expectedIds = Array.from(
+         { length: page1.data.length + page2.data.length },
+         (_, i) => i + 1
+      );
+      expect(allIds).toEqual(expectedIds);
+   });
+});
+
 describe('buildPaginatedResponse', () => {
    const items = [
       { id: 1, name: 'Alice' },


### PR DESCRIPTION
# Closes #646 

## Summary

Adds a new **`paginateQuery – multi-page coverage with 15 trade records`** test suite to the existing `pagination.utils.test.ts` that validates keyset cursor pagination produces no gaps or duplicates across page boundaries.

## Acceptance criteria covered

| Criterion | Test |
|---|---|
| All 15 records covered across three pages | `covers all 15 records across three pages with no duplicates` – collects all items across pages 1–3 and asserts `toHaveLength(15)` and `new Set(…).size === 15` |
| No record appears on more than one page | Same test uses `Set` uniqueness check on collected ids |
| Page 3 returns `hasMore: false` | Separate `final page returns hasMore false` test, plus implicit assertion in the coverage test |
| Cursors from each page correctly advance | `each page cursor correctly advances to the next set` explicitly checks ids match `[1,2,3,4,5]`, `[6,7,8,9,10]`, `[11,12,13,14,15]` |
| No records skipped between pages | `no records are skipped between pages` verifies ids across first two pages are contiguous |

## Test structure

- **Trade records** – 15 deterministic objects with `id`, `ledger` (500000–500014), and `tx_hash` (`0x`-padded) fields
- **Mock query** – simulates Prisma cursor pagination (over-fetch + skip cursor item) on the in-memory array
- **Limit** – 5 per page → exactly 3 pages
- **Assertion style** – follows the project convention (`.toHaveLength`, `.toEqual`, `.toBeUndefined`)

## Files changed

- `src/utils/test/pagination.utils.test.ts` — added 128 lines, 4 new tests (11 total, all passing)