### PR TITLE
feat(indexer): add structured warn log for checkpoint write failure (#644)

### DIFF
--- a/src/modules/indexer/indexer-pipeline.integration.test.ts
+++ b/src/modules/indexer/indexer-pipeline.integration.test.ts
@@ -17,6 +17,9 @@ jest.mock('../../utils/prisma.utils', () => ({
          create: jest.fn(),
          update: jest.fn(),
       },
+      indexedLedger: {
+         upsert: jest.fn(),
+      },
    },
 }));
 
@@ -34,15 +37,17 @@ describe('processTradeEvents integration test', () => {
       activity: { create: jest.Mock };
       keyOwnership: { findFirst: jest.Mock; upsert: jest.Mock };
       creatorPriceSnapshot: { findUnique: jest.Mock; create: jest.Mock; update: jest.Mock };
+      indexedLedger: { upsert: jest.Mock };
    };
    const mockLogger = logger as unknown as {
       warn: jest.Mock;
    };
 
-   beforeEach(() => {
-      jest.clearAllMocks();
-      mockPrisma.keyOwnership.upsert.mockResolvedValue({ balance: -50 });
-   });
+    beforeEach(() => {
+       jest.clearAllMocks();
+       mockPrisma.keyOwnership.upsert.mockResolvedValue({ balance: -50 });
+       mockPrisma.indexedLedger.upsert.mockResolvedValue({});
+    });
 
    it('correctly processes and persists a valid sell event', async () => {
       const event: IndexerChainEvent = {
@@ -127,27 +132,62 @@ describe('processTradeEvents integration test', () => {
       expect(mockPrisma.activity.create).toHaveBeenCalledTimes(1);
    });
 
-   it('skips a sell event with missing required fields and logs a warning', async () => {
-      const malformedEvent: IndexerChainEvent = {
-         txHash: '0xhash123',
-         eventIndex: 0,
-         eventType: 'KEY_SOLD',
-         ledger: 12345,
-         // creatorId is missing
-         actor: 'G_SELLER_ADDRESS',
-         amount: 50,
-         price: 2000n,
-         feePaid: 10n,
-         tradeAt: '2026-07-25T12:00:00.000Z',
-      } as any;
+    it('skips a sell event with missing required fields and logs a warning', async () => {
+       const malformedEvent: IndexerChainEvent = {
+          txHash: '0xhash123',
+          eventIndex: 0,
+          eventType: 'KEY_SOLD',
+          ledger: 12345,
+          // creatorId is missing
+          actor: 'G_SELLER_ADDRESS',
+          amount: 50,
+          price: 2000n,
+          feePaid: 10n,
+          tradeAt: '2026-07-25T12:00:00.000Z',
+       } as any;
 
-      await processTradeEvents([malformedEvent]);
+       await processTradeEvents([malformedEvent]);
 
-      expect(mockPrisma.activity.create).not.toHaveBeenCalled();
-      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-         expect.objectContaining({ missingField: 'creatorId' }),
-         expect.any(String)
-      );
-   });
+       expect(mockPrisma.activity.create).not.toHaveBeenCalled();
+       expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+       expect(mockLogger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ missingField: 'creatorId' }),
+          expect.any(String)
+       );
+    });
+
+    it('emits a warn log when checkpoint write fails and continues processing', async () => {
+       const event: IndexerChainEvent = {
+          txHash: '0xhash456',
+          eventIndex: 0,
+          eventType: 'KEY_SOLD',
+          ledger: 99999,
+          creatorId: 'creator-xyz',
+          actor: 'G_BUYER_ADDRESS',
+          amount: 30,
+          price: 1500n,
+          feePaid: 5n,
+          tradeAt: '2026-07-25T13:00:00.000Z',
+       };
+
+       mockPrisma.keyOwnership.findFirst.mockResolvedValue(null);
+       mockPrisma.creatorPriceSnapshot.findUnique.mockResolvedValue(null);
+       mockPrisma.indexedLedger.upsert.mockRejectedValue(new Error('DB timeout'));
+
+       await processTradeEvents([event]);
+
+       // Processing still completes despite checkpoint failure
+       expect(mockPrisma.activity.create).toHaveBeenCalledTimes(1);
+
+       // A warn log is emitted for the checkpoint failure
+       expect(mockLogger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({
+             ledger: 99999,
+             error_reason: 'DB timeout',
+             failed_at: expect.any(String),
+             batch_hash: expect.any(String),
+          }),
+          'Indexer checkpoint write failed'
+       );
+    });
 });

--- a/src/modules/indexer/indexer-pipeline.service.ts
+++ b/src/modules/indexer/indexer-pipeline.service.ts
@@ -1,8 +1,11 @@
+import { createHash } from 'crypto';
 import { prisma } from '../../utils/prisma.utils';
 import { updateOwnership } from '../ownership/ownership.service';
 import { upsertPriceSnapshot } from './price-snapshot.service';
+import { updateIndexedLedger } from './ledger-gap-detection.service';
 import { logger } from '../../utils/logger.utils';
 import { processIndexerChainEvents, IndexerChainEvent } from '../../utils/indexer-event-processor.utils';
+import { dedupeChainEvents } from '../../utils/indexer-dedupe.utils';
 
 /**
  * Processes a batch of on-chain trade events (KEY_BOUGHT or KEY_SOLD).
@@ -12,6 +15,7 @@ import { processIndexerChainEvents, IndexerChainEvent } from '../../utils/indexe
  * - Creates an Activity record (representing the trade).
  * - Updates the KeyOwnership read model.
  * - Upserts the CreatorPriceSnapshot read model.
+ * - Writes a checkpoint record of the highest ledger processed.
  */
 export async function processTradeEvents(events: IndexerChainEvent[]): Promise<void> {
    await processIndexerChainEvents(events, async (event) => {
@@ -65,4 +69,25 @@ export async function processTradeEvents(events: IndexerChainEvent[]): Promise<v
          ledger: Number(ledger),
       });
    });
+
+   const uniqueEvents = dedupeChainEvents(events);
+
+   const processedLedgers = uniqueEvents
+      .map(e => e.ledger)
+      .filter((l): l is number => typeof l === 'number');
+
+   if (processedLedgers.length > 0) {
+      const maxLedger = Math.max(...processedLedgers);
+      const batchHash = computeBatchHash(uniqueEvents);
+      const cursor = `${maxLedger}-000`;
+      await updateIndexedLedger(maxLedger, cursor, batchHash);
+   }
+}
+
+function computeBatchHash(events: Array<{ txHash: string; eventIndex: number }>): string {
+   const identifiers = events
+      .map(e => `${e.txHash}:${e.eventIndex}`)
+      .sort()
+      .join('|');
+   return createHash('sha256').update(identifiers, 'utf8').digest('hex').slice(0, 16);
 }

--- a/src/modules/indexer/ledger-gap-detection.service.ts
+++ b/src/modules/indexer/ledger-gap-detection.service.ts
@@ -1,6 +1,3 @@
-// src/modules/indexer/ledger-gap-detection.service.ts
-// Detects gaps in processed ledger sequences and logs warnings.
-
 import { prisma } from '../../utils/prisma.utils';
 import { logger } from '../../utils/logger.utils';
 
@@ -95,21 +92,35 @@ export async function detectLedgerGap(): Promise<LedgerGap> {
  *
  * @param ledger - The ledger sequence number just processed.
  * @param cursor - The opaque cursor for resumption.
+ * @param batchHash - Optional SHA-256 hash of the batch identifiers for log correlation.
  */
 export async function updateIndexedLedger(
    ledger: number,
-   cursor: string
+   cursor: string,
+   batchHash?: string
 ): Promise<void> {
-   await prisma.indexedLedger.upsert({
-      where: { id: 1 },
-      create: {
-         id: 1,
-         ledger,
-         cursor,
-      },
-      update: {
-         ledger,
-         cursor,
-      },
-   });
+   try {
+      await prisma.indexedLedger.upsert({
+         where: { id: 1 },
+         create: {
+            id: 1,
+            ledger,
+            cursor,
+         },
+         update: {
+            ledger,
+            cursor,
+         },
+      });
+   } catch (err) {
+      logger.warn(
+         {
+            batch_hash: batchHash ?? null,
+            error_reason: err instanceof Error ? err.message : String(err),
+            failed_at: new Date().toISOString(),
+            ledger,
+         },
+         'Indexer checkpoint write failed'
+      );
+   }
 }


### PR DESCRIPTION
Closes #644

---

## Summary

Adds structured warn-level logging when the idempotent ledger checkpoint write `updateIndexedLedger` fails (DB error or timeout). Previously, checkpoint write failures were silent; now operators get a structured log with all relevant metadata to identify ledger ranges at risk of duplicate processing after a restart.

## Changes

- **ledger-gap-detection.service.ts**: `updateIndexedLedger` now wraps `prisma.indexedLedger.upsert` in try/catch. On failure, emits a structured warn log with: `ledger`, `batch_hash`, `error_reason`, `failed_at` — no trade event data included.
- **indexer-pipeline.service.ts**: `processTradeEvents` now calls `updateIndexedLedger` after processing each batch, computing a SHA-256 batch hash from event identifiers (txHash:eventIndex only — no trade data).
- **indexer-pipeline.integration.test.ts**: Added `indexedLedger.upsert` mock and a new test case verifying the checkpoint failure warn log is emitted with correct fields while the pipeline continues processing.

## Acceptance Criteria Checklist

- [x] Warn log emitted on checkpoint write failure
- [x] All four fields present with correct values (ledger, batch_hash, error_reason, failed_at)
- [x] Trade event data absent from the log
- [x] Log emitted before the indexer moves to the next ledger

## Test Results

- All 4 pipeline integration tests pass
- TypeScript compilation clean
- ESLint clean
- Lint/typecheck: `npx tsc --noEmit` && `npx eslint --ext .ts src/` — no errors