### PR TITLE
test: add integration tests for webhook 404 responses on non-existent IDs

### DIFF
--- a/src/modules/webhooks/webhook.controllers.ts
+++ b/src/modules/webhooks/webhook.controllers.ts
@@ -6,7 +6,7 @@ import {
    sendNotFound,
 } from '../../utils/api-response.utils';
 import { ErrorCode } from '../../constants/error.constants';
-import { CreateWebhookSchema } from './webhook.schemas';
+import { CreateWebhookSchema, UpdateWebhookSchema } from './webhook.schemas';
 import * as webhookService from './webhook.service';
 import type { WalletSignedRequest } from './webhook-signature.middleware';
 
@@ -78,17 +78,92 @@ export async function deleteWebhookHandler(
       return;
    }
 
-   try {
-      const result = await webhookService.deleteWebhook(
-         webhookId,
-         req.creatorId!
-      );
-      if (!result) {
-         sendNotFound(res, 'Webhook');
-         return;
-      }
-      res.status(204).end();
-   } catch {
-      sendError(res, 500, ErrorCode.INTERNAL_ERROR, 'Failed to delete webhook');
-   }
+    try {
+       const result = await webhookService.deleteWebhook(
+          webhookId,
+          req.creatorId!
+       );
+       if (!result) {
+          sendNotFound(res, 'Webhook');
+          return;
+       }
+       res.status(204).end();
+    } catch {
+       sendError(res, 500, ErrorCode.INTERNAL_ERROR, 'Failed to delete webhook');
+    }
+}
+
+export async function getWebhookHandler(
+    req: WalletSignedRequest,
+    res: Response
+) {
+    const rawWebhookId = req.params.webhookId;
+    const webhookId = Array.isArray(rawWebhookId)
+       ? rawWebhookId[0]
+       : rawWebhookId;
+
+    if (!webhookId) {
+       sendError(res, 400, ErrorCode.BAD_REQUEST, 'Missing webhook ID in path');
+       return;
+    }
+
+    try {
+       const result = await webhookService.getWebhook(
+          webhookId,
+          req.creatorId!
+       );
+       if (!result) {
+          sendNotFound(res, 'Webhook');
+          return;
+       }
+       sendSuccess(res, result);
+    } catch {
+       sendError(res, 500, ErrorCode.INTERNAL_ERROR, 'Failed to get webhook');
+    }
+}
+
+export async function updateWebhookHandler(
+    req: WalletSignedRequest,
+    res: Response
+) {
+    const rawWebhookId = req.params.webhookId;
+    const webhookId = Array.isArray(rawWebhookId)
+       ? rawWebhookId[0]
+       : rawWebhookId;
+
+    if (!webhookId) {
+       sendError(res, 400, ErrorCode.BAD_REQUEST, 'Missing webhook ID in path');
+       return;
+    }
+
+    const parseResult = UpdateWebhookSchema.safeParse(req.body);
+    if (!parseResult.success) {
+       sendValidationError(
+          res,
+          'Invalid webhook update payload',
+          parseResult.error.issues.map(issue => ({
+             field: issue.path.join('.'),
+             message: issue.message,
+          }))
+       );
+       return;
+    }
+
+    try {
+       const result = await webhookService.updateWebhook(
+          webhookId,
+          req.creatorId!,
+          {
+             callbackUrl: parseResult.data.callback_url,
+             events: parseResult.data.events,
+          }
+       );
+       if (!result) {
+          sendNotFound(res, 'Webhook');
+          return;
+       }
+       sendSuccess(res, result);
+    } catch {
+       sendError(res, 500, ErrorCode.INTERNAL_ERROR, 'Failed to update webhook');
+    }
 }

--- a/src/modules/webhooks/webhook.integration.test.ts
+++ b/src/modules/webhooks/webhook.integration.test.ts
@@ -247,19 +247,26 @@ describe('DELETE /api/v1/creators/:id/webhooks/:webhookId', () => {
       expect(ids).not.toContain(webhookId);
    });
 
-   it('returns 404 for non-existent webhook', async () => {
-      const res = await supertest(app)
-         .delete(`/api/v1/creators/${creatorId}/webhooks/non-existent-id`)
-         .set(
-            authHeaders(
-               'DELETE',
-               `/api/v1/creators/${creatorId}/webhooks/non-existent-id`,
-               creatorId
-            )
-         );
+    it('returns 404 for non-existent webhook', async () => {
+       const res = await supertest(app)
+          .delete(`/api/v1/creators/${creatorId}/webhooks/non-existent-id`)
+          .set(
+             authHeaders(
+                'DELETE',
+                `/api/v1/creators/${creatorId}/webhooks/non-existent-id`,
+                creatorId
+             )
+          );
 
-      expect(res.status).toBe(404);
-   });
+       expect(res.status).toBe(404);
+       expect(res.body).toEqual({
+          success: false,
+          error: {
+             code: 'NOT_FOUND',
+             message: 'Webhook not found',
+          },
+       });
+    });
 
    it('stops future deliveries when a webhook is deleted (#506)', async () => {
       // Register a webhook and confirm it exists
@@ -310,6 +317,53 @@ describe('DELETE /api/v1/creators/:id/webhooks/:webhookId', () => {
       });
 
       expect(events.length).toBe(0);
+   });
+});
+
+describe('GET /api/v1/creators/:id/webhooks/:webhookId', () => {
+   it('returns 404 for non-existent webhook', async () => {
+      const res = await supertest(app)
+         .get(`/api/v1/creators/${creatorId}/webhooks/non-existent-id`)
+         .set(
+            authHeaders(
+               'GET',
+               `/api/v1/creators/${creatorId}/webhooks/non-existent-id`,
+               creatorId
+            )
+         );
+
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({
+         success: false,
+         error: {
+            code: 'NOT_FOUND',
+            message: 'Webhook not found',
+         },
+      });
+   });
+});
+
+describe('PATCH /api/v1/creators/:id/webhooks/:webhookId', () => {
+   it('returns 404 for non-existent webhook', async () => {
+      const res = await supertest(app)
+         .patch(`/api/v1/creators/${creatorId}/webhooks/non-existent-id`)
+         .set(
+            authHeaders(
+               'PATCH',
+               `/api/v1/creators/${creatorId}/webhooks/non-existent-id`,
+               creatorId
+            )
+         )
+         .send({ callback_url: 'https://example.com/updated' });
+
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({
+         success: false,
+         error: {
+            code: 'NOT_FOUND',
+            message: 'Webhook not found',
+         },
+      });
    });
 });
 

--- a/src/modules/webhooks/webhook.router.ts
+++ b/src/modules/webhooks/webhook.router.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 import { requireWalletSignature } from './webhook-signature.middleware';
 import {
-   registerWebhookHandler,
-   listWebhooksHandler,
-   deleteWebhookHandler,
+    registerWebhookHandler,
+    listWebhooksHandler,
+    deleteWebhookHandler,
+    getWebhookHandler,
+    updateWebhookHandler,
 } from './webhook.controllers';
 
 const router = Router();
@@ -12,10 +14,22 @@ router.post('/:id/webhooks', requireWalletSignature(), registerWebhookHandler);
 
 router.get('/:id/webhooks', requireWalletSignature(), listWebhooksHandler);
 
+router.get(
+    '/:id/webhooks/:webhookId',
+    requireWalletSignature(),
+    getWebhookHandler
+);
+
+router.patch(
+    '/:id/webhooks/:webhookId',
+    requireWalletSignature(),
+    updateWebhookHandler
+);
+
 router.delete(
-   '/:id/webhooks/:webhookId',
-   requireWalletSignature(),
-   deleteWebhookHandler
+    '/:id/webhooks/:webhookId',
+    requireWalletSignature(),
+    deleteWebhookHandler
 );
 
 export default router;

--- a/src/modules/webhooks/webhook.schemas.ts
+++ b/src/modules/webhooks/webhook.schemas.ts
@@ -8,32 +8,64 @@ export const WebhookEventEnum = z.enum(['buy', 'sell']);
  * plain-HTTP or hostless callback URLs are rejected outright (#613).
  */
 export const CreateWebhookSchema = z.object({
-   callback_url: z
-      .string()
-      .url('callback_url must be a valid URL')
-      .refine(
-         value => {
-            try {
-               return new URL(value).protocol === 'https:';
-            } catch {
-               return false;
-            }
-         },
-         { message: 'callback_url must use https://' }
-      )
-      .refine(
-         value => {
-            try {
-               return new URL(value).hostname.length > 0;
-            } catch {
-               return false;
-            }
-         },
-         { message: 'callback_url must include a host' }
-      ),
-   events: z
-      .array(WebhookEventEnum, { required_error: 'events is required' })
-      .min(1, 'At least one event type is required'),
+    callback_url: z
+       .string()
+       .url('callback_url must be a valid URL')
+       .refine(
+          value => {
+             try {
+                return new URL(value).protocol === 'https:';
+             } catch {
+                return false;
+             }
+          },
+          { message: 'callback_url must use https://' }
+       )
+       .refine(
+          value => {
+             try {
+                return new URL(value).hostname.length > 0;
+             } catch {
+                return false;
+             }
+          },
+          { message: 'callback_url must include a host' }
+       ),
+    events: z
+       .array(WebhookEventEnum, { required_error: 'events is required' })
+       .min(1, 'At least one event type is required'),
+});
+
+export const UpdateWebhookSchema = z.object({
+    callback_url: z
+       .string()
+       .url('callback_url must be a valid URL')
+       .refine(
+          value => {
+             try {
+                return new URL(value).protocol === 'https:';
+             } catch {
+                return false;
+             }
+          },
+          { message: 'callback_url must use https://' }
+       )
+       .refine(
+          value => {
+             try {
+                return new URL(value).hostname.length > 0;
+             } catch {
+                return false;
+             }
+          },
+          { message: 'callback_url must include a host' }
+       )
+       .optional(),
+    events: z
+       .array(WebhookEventEnum, { required_error: 'events is required' })
+       .min(1, 'At least one event type is required')
+       .optional(),
 });
 
 export type CreateWebhookType = z.infer<typeof CreateWebhookSchema>;
+export type UpdateWebhookType = z.infer<typeof UpdateWebhookSchema>;

--- a/src/modules/webhooks/webhook.service.ts
+++ b/src/modules/webhooks/webhook.service.ts
@@ -4,11 +4,12 @@ import { envConfig } from '../../config';
 import { maskWebhookUrl } from '../../utils/webhook-mask.utils';
 import { buildWebhookPayload } from './webhook-payload.utils';
 import type {
-   CreateWebhookInput,
-   TradeEvent,
-   WebhookEventPayload,
-   WebhookEventName,
-   WebhookResponse,
+    CreateWebhookInput,
+    UpdateWebhookInput,
+    TradeEvent,
+    WebhookEventPayload,
+    WebhookEventName,
+    WebhookResponse,
 } from './webhook.types';
 
 function normalizeEvents(events: string[]): ('BUY' | 'SELL')[] {
@@ -75,26 +76,79 @@ export async function listWebhooks(creatorId: string): Promise<WebhookResponse[]
 }
 
 export async function deleteWebhook(webhookId: string, creatorId: string) {
-   const webhook = await prisma.webhook.findFirst({
-      where: { id: webhookId, creatorId },
-   });
+    const webhook = await prisma.webhook.findFirst({
+       where: { id: webhookId, creatorId },
+    });
 
-   if (!webhook) {
-      return null;
-   }
+    if (!webhook) {
+       return null;
+    }
 
-   await prisma.webhook.delete({ where: { id: webhookId } });
+    await prisma.webhook.delete({ where: { id: webhookId } });
 
-   logger.info(
-      {
-         creator_id: creatorId,
-         webhook_id: webhookId,
-         deleted_at: new Date().toISOString(),
-      },
-      'Webhook deleted'
-   );
+    logger.info(
+       {
+          creator_id: creatorId,
+          webhook_id: webhookId,
+          deleted_at: new Date().toISOString(),
+       },
+       'Webhook deleted'
+    );
 
-   return { id: webhookId };
+    return { id: webhookId };
+}
+
+export async function getWebhook(webhookId: string, creatorId: string) {
+    const webhook = await prisma.webhook.findFirst({
+       where: { id: webhookId, creatorId },
+    });
+
+    if (!webhook) {
+       return null;
+    }
+
+    return {
+       ...webhook,
+       events: denormalizeEvents(webhook.events as ('BUY' | 'SELL')[]),
+    };
+}
+
+export async function updateWebhook(
+    webhookId: string,
+    creatorId: string,
+    input: UpdateWebhookInput
+) {
+    const webhook = await prisma.webhook.findFirst({
+       where: { id: webhookId, creatorId },
+    });
+
+    if (!webhook) {
+       return null;
+    }
+
+    const updated = await prisma.webhook.update({
+       where: { id: webhookId },
+       data: {
+          callbackUrl: input.callbackUrl ?? webhook.callbackUrl,
+          events: input.events
+             ? { set: normalizeEvents(input.events) }
+             : undefined,
+       },
+    });
+
+    logger.info(
+       {
+          creator_id: creatorId,
+          webhook_id: webhookId,
+          updated_at: new Date().toISOString(),
+       },
+       'Webhook updated'
+    );
+
+    return {
+       ...updated,
+       events: denormalizeEvents(updated.events as ('BUY' | 'SELL')[]),
+    };
 }
 
 export async function dispatchWebhookEvent(tradeEvent: TradeEvent) {

--- a/src/modules/webhooks/webhook.types.ts
+++ b/src/modules/webhooks/webhook.types.ts
@@ -5,6 +5,11 @@ export interface CreateWebhookInput {
    events: WebhookEventName[];
 }
 
+export interface UpdateWebhookInput {
+   callbackUrl?: string;
+   events?: WebhookEventName[];
+}
+
 export interface WebhookResponse {
    id: string;
    creatorId: string;


### PR DESCRIPTION
Closes #647

---

Add GET detail and PATCH update endpoints for webhooks, and integration
tests that confirm all three endpoints (GET, PATCH, DELETE) return 404
with a descriptive error body when a non-existent webhook ID is targeted.

- Add getWebhook() and updateWebhook() service functions
- Add getWebhookHandler and updateWebhookHandler controller handlers
- Add UpdateWebhookSchema for PATCH request validation
- Add GET and PATCH routes under /:id/webhooks/:webhookId
- Add integration tests verifying 404 status and error body shape
- Update existing DELETE 404 test to verify error body shape
