### PR TITLE
#664 Add structured log for each price alert delivery attempt with threshold, current price, and delivery status

### DIFF
--- a/src/modules/alerts/alert.service.ts
+++ b/src/modules/alerts/alert.service.ts
@@ -140,8 +140,8 @@ async function deliverPriceAlertWebhook(
 ): Promise<void> {
    const maxAttempts = envConfig.WEBHOOK_RETRY_MAX_ATTEMPTS;
    const maskedUrl = maskCallbackUrl(alert.callbackUrl);
-   const threshold = toNumber(alert.targetPrice);
-   const triggeredPrice = toNumber(payload.current_price);
+   const threshold = toNumber(alert.targetPrice as string | number | { toString(): string });
+   const triggeredPrice = toNumber(payload.current_price as string | number | { toString(): string });
 
    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       const attemptedAt = new Date();

--- a/src/modules/alerts/alert.service.ts
+++ b/src/modules/alerts/alert.service.ts
@@ -140,8 +140,11 @@ async function deliverPriceAlertWebhook(
 ): Promise<void> {
    const maxAttempts = envConfig.WEBHOOK_RETRY_MAX_ATTEMPTS;
    const maskedUrl = maskCallbackUrl(alert.callbackUrl);
+   const threshold = toNumber(alert.targetPrice);
+   const triggeredPrice = toNumber(payload.current_price);
 
    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const attemptedAt = new Date();
       try {
          const response = await fetch(alert.callbackUrl, {
             method: 'POST',
@@ -153,6 +156,18 @@ async function deliverPriceAlertWebhook(
             throw new Error(`HTTP_${response.status}`);
          }
 
+         logger.debug(
+            {
+               alert_id: alert.id,
+               creator_id: alert.creatorId,
+               threshold,
+               triggered_price: triggeredPrice,
+               delivery_status: 'success',
+               attempted_at: attemptedAt,
+            },
+            'Price alert delivery attempt completed'
+         );
+
          return;
       } catch (error) {
          const logFields = {
@@ -163,6 +178,18 @@ async function deliverPriceAlertWebhook(
                error instanceof Error ? error.message : 'Unknown error',
             masked_url: maskedUrl,
          };
+
+         logger.debug(
+            {
+               alert_id: alert.id,
+               creator_id: alert.creatorId,
+               threshold,
+               triggered_price: triggeredPrice,
+               delivery_status: 'failed',
+               attempted_at: attemptedAt,
+            },
+            'Price alert delivery attempt completed'
+         );
 
          if (attempt === maxAttempts) {
             logger.error(


### PR DESCRIPTION
Summary
Adds structured debug-level logging for each price alert webhook delivery attempt to improve operational observability. Previously, no log was emitted when a price alert delivery was attempted, making it difficult for operators to trace alert delivery activity or diagnose missed/duplicate deliveries without querying the database.

The implementation adds a debug log entry immediately after each delivery attempt completes (both successful and failed), containing:

alert_id: Unique identifier of the price alert
creator_id: Creator whose key price triggered the alert
threshold: Target price threshold configured for the alert
triggered_price: Actual price that triggered the alert
delivery_status: Outcome of the delivery attempt ("success" or "failed")
attempted_at: Timestamp when the delivery attempt was made
The callback URL is intentionally excluded from the debug log to avoid exposing sensitive endpoint information. Existing warn/error logs with masked URLs remain for debugging delivery failures.

Testing
pnpm lint
pnpm build
pnpm exec prisma generate when schema or generated types changed
Checklist
Linked issue or backlog item (#664)
No secrets or live credentials added
Docs updated if setup or env changed
Change is scoped to one problem

closes #664 