### PR TITLE
fix(middleware): use parametrised route pattern in request completion logger (#668)

### DIFF
--- a/src/middlewares/request-completion-logger.middleware.ts
+++ b/src/middlewares/request-completion-logger.middleware.ts
@@ -6,9 +6,13 @@ import { logger } from '../utils/logger.utils';
 // Emits a structured log with:
 // - request_id
 // - method
-// - path
+// - route (parametrised, e.g. /api/v1/creators/:id)
 // - status_code
 // - response_time_ms
+//
+// The route field uses the matched Express route pattern (req.route.path)
+// so log keys are low-cardinality. Falls back to the raw path when no
+// route matches (e.g. 404s).
 //
 // Log level rules:
 // - error for 5xx responses
@@ -33,13 +37,19 @@ export const requestCompletionLoggerMiddleware = (
       const responseTimeMs = diff[0] * 1e3 + diff[1] * 1e-6;
 
       const statusCode = res.statusCode;
-      const path = req.path;
       const method = req.method;
+
+      // Use the parametrised Express route pattern when available to avoid
+      // high-cardinality log keys. Falls back to req.path for unmatched
+      // routes (e.g. 404s).
+      const route = req.route
+         ? req.baseUrl + req.route.path
+         : req.baseUrl + req.path;
 
       const payload = {
          request_id: requestId,
          method,
-         path,
+         route,
          status_code: statusCode,
          response_time_ms: Math.round(responseTimeMs),
       };


### PR DESCRIPTION
## Summary

Closes #668

The request completion logger middleware was emitting the raw `req.path` (e.g. `/creators/GABC123DEF456`) in log entries, creating high-cardinality log keys that make it impossible to aggregate by route. This PR changes the route field to use the parametrised Express route pattern (e.g. `/api/v1/creators/:id`) via `req.baseUrl + req.route.path`, enabling route-level request rate and p95 latency calculations from logs.

## Changes

- **`src/middlewares/request-completion-logger.middleware.ts`** — Replaced `req.path` with the parametrised route pattern (`req.baseUrl + req.route.path`). Falls back to `req.baseUrl + req.path` when no route matches (e.g. 404s). Renamed the log payload field from `path` to `route`.

## How It Works

```ts
// Before (high-cardinality)
const path = req.path;
// => "/creators/GABC123DEF456"

// After (low-cardinality, parametrised)
const route = req.route
  ? req.baseUrl + req.route.path
  : req.baseUrl + req.path;
// => "/api/v1/creators/:id"
```

Express sets `req.route` when a route handler is matched. By the time the `finish` event fires, `req.route` is available for all matched routes. For unmatched routes (404s), the fallback preserves the raw path so those requests are still logged.

## Log Output Example

```json
{
  "level": "info",
  "request_id": "abc-123",
  "method": "GET",
  "route": "/api/v1/creators/:id",
  "status_code": 200,
  "response_time_ms": 42,
  "msg": "Request completed"
}
```

## Acceptance Criteria

- [x] Log emitted for every API request after response is sent
- [x] All four fields present with correct values (method, route, status_code, response_time_ms)
- [x] Route is the parametrised pattern, not the raw URL
- [x] response_time_ms reflects full request-to-response time (measured via `process.hrtime` from middleware entry to `finish` event)
