### PR TITLE
test: add unit tests for compute24hPriceChange at positive, negative, zero, and fractional scenarios

### DIFF
--- a/src/utils/__tests__/price.utils.test.ts
+++ b/src/utils/__tests__/price.utils.test.ts
@@ -1,15 +1,15 @@
 import { compute24hPriceChange } from '../price.utils';
 
 describe('compute24hPriceChange()', () => {
-   it('returns a positive percentage when the price increases', () => {
-      expect(compute24hPriceChange(120n, 100n)).toBe(20);
+   it('returns a positive percentage when the price increases (oldest 100, latest 150 → 50.00)', () => {
+      expect(compute24hPriceChange(150n, 100n)).toBe(50);
    });
 
-   it('returns a negative percentage when the price decreases', () => {
-      expect(compute24hPriceChange(80n, 100n)).toBe(-20);
+   it('returns a negative percentage when the price decreases (oldest 200, latest 100 → -50.00)', () => {
+      expect(compute24hPriceChange(100n, 200n)).toBe(-50);
    });
 
-   it('returns 0 when the price is unchanged', () => {
+   it('returns 0 when the price is unchanged (oldest 100, latest 100 → 0.00)', () => {
       expect(compute24hPriceChange(100n, 100n)).toBe(0);
    });
 
@@ -17,7 +17,7 @@ describe('compute24hPriceChange()', () => {
       expect(compute24hPriceChange(100n, 0n)).toBe(0);
    });
 
-   it('rounds long decimal values to exactly two decimal places', () => {
-      expect(compute24hPriceChange(101n, 3n)).toBe(3266.67);
+   it('rounds fractional result to two decimal places (oldest 3, latest 4 → 33.33)', () => {
+      expect(compute24hPriceChange(4n, 3n)).toBe(33.33);
    });
 });


### PR DESCRIPTION
Closes #661

## Summary
- Add unit tests for compute24hPriceChange covering all three sign outcomes
- Positive change (oldest 100, latest 150 → 50.00)
- Negative change (oldest 200, latest 100 → -50.00)
- Zero change (oldest 100, latest 100 → 0.00) and fractional rounding (oldest 3, latest 4 → 33.33)

## Testing
Ran `pnpm exec jest src/utils/__tests__/price.utils.test.ts` — all 5 tests pass.