### PR TITLE
test(creators): assert no leaked internals and 404 shape parity for creator detail

### DIFF
--- a/src/modules/creators/creator-detail-not-found.integration.test.ts
+++ b/src/modules/creators/creator-detail-not-found.integration.test.ts
@@ -31,4 +31,56 @@ describe('GET /api/v1/creators/:id — not found', () => {
       expect(res.body.error.code).toBe('NOT_FOUND');
       expect(res.body.error.message).toMatch(/creator.*not found/i);
    });
+
+   it('matches the standard 404 response shape used by other creator routes', async () => {
+      const { default: app } = await import('../../app');
+
+      const res = await supertest(app).get(
+         '/api/v1/creators/non-existent-creator-for-404-test'
+      );
+
+      // Same envelope as GET /:id/holders and other 404s in the API:
+      // exactly { success, error: { code, message } }, no extra fields.
+      expect(res.body).toEqual({
+         success: false,
+         error: {
+            code: 'NOT_FOUND',
+            message: 'Creator not found',
+         },
+      });
+   });
+
+   it('does not leak database errors, table/model names, or stack traces', async () => {
+      const { default: app } = await import('../../app');
+
+      const res = await supertest(app).get(
+         '/api/v1/creators/non-existent-creator-for-404-test'
+      );
+
+      const serializedBody = JSON.stringify(res.body).toLowerCase();
+
+      const forbiddenPatterns = [
+         'stack',
+         'trace',
+         'prisma',
+         'creatorprofile',
+         'creator_profile',
+         'select ',
+         'sql',
+         '.ts:',
+         '.js:',
+         'node_modules',
+         'at object',
+         'errno',
+         'econnrefused',
+      ];
+
+      for (const pattern of forbiddenPatterns) {
+         expect(serializedBody).not.toContain(pattern);
+      }
+
+      // Only the documented error keys should be present—nothing
+      // implementation-specific like a Prisma error `code`/`meta`/`clientVersion`.
+      expect(Object.keys(res.body.error).sort()).toEqual(['code', 'message']);
+   });
 });


### PR DESCRIPTION
Closes #665

## Summary

The creator detail endpoint (`GET /api/v1/creators/:id`) already returns a 404 for a non-existent creator, and a basic integration test for that already existed. This PR extends that test to explicitly cover the remaining acceptance criteria from #665 that weren't yet asserted:

- Response shape is identical to the standard 404 envelope used elsewhere in the API (e.g. `GET /:id/holders`), with no extra/unexpected fields.
- The response body does not leak internal implementation details: no Prisma error internals, no DB table/model names, no stack traces, no file paths, no low-level DB error codes (e.g. `ECONNREFUSED`).

## Files changed

- **Modified:** `src/modules/creators/creator-detail-not-found.integration.test.ts` — added two new test cases to the existing `describe('GET /api/v1/creators/:id — not found')` block.

No production code was changed — the 404 behavior itself (`httpGetCreator` in `src/modules/creators/creators.controllers.ts`, using `sendNotFound`) already satisfied the requirements; this PR closes the test-coverage gap.

## Implementation details

Two new `it()` blocks were added to the existing integration test:

1. **`matches the standard 404 response shape used by other creator routes`** — asserts `res.body` is *exactly* `{ success: false, error: { code: 'NOT_FOUND', message: 'Creator not found' } }` via `toEqual`, matching the shape already verified for `GET /:id/holders` in `src/__tests__/integration/creator-holders-404.test.ts`.
2. **`does not leak database errors, table/model names, or stack traces`** — serializes the response body to a lowercased JSON string and asserts it does not contain any of a list of forbidden substrings (`stack`, `trace`, `prisma`, `creatorprofile`, `creator_profile`, `select `, `sql`, `.ts:`, `.js:`, `node_modules`, `at object`, `errno`, `econnrefused`). It also asserts `error` object keys are exactly `['code', 'message']`, ruling out leaked fields like Prisma's `meta`/`clientVersion`.

Both tests reuse the existing mocking setup in the file (`creatorProfileExists` mocked to resolve `false`, `prisma.utils` mocked) so no real database is needed.

## Tests added

- `src/modules/creators/creator-detail-not-found.integration.test.ts`
  - `returns 404 with the standard error shape for a non-existent creator` (pre-existing, unchanged)
  - `matches the standard 404 response shape used by other creator routes` (new)
  - `does not leak database errors, table/model names, or stack traces` (new)

## How to test

```bash
pnpm install
pnpm generate   # generates the Prisma client used by src/app.ts
npx jest src/modules/creators/creator-detail-not-found.integration.test.ts
```

Expected: 3 passing tests, 0 failing.

I also ran `pnpm lint`, `pnpm build`, and the full `jest` suite locally — lint and build are clean, and this change does not introduce any new test failures (pre-existing failures elsewhere in the suite, e.g. `creator-list-item.mapper.test.ts` and `creator-list-page.guard.test.ts`, are unrelated to this change and reproduce identically on `main` without it).
